### PR TITLE
terracli treasuryClient reference target change

### DIFF
--- a/cmd/terracli/main.go
+++ b/cmd/terracli/main.go
@@ -20,7 +20,7 @@ import (
 	budgetClient "terra/x/budget/client"
 	marketClient "terra/x/market/client"
 	oracleClient "terra/x/oracle/client"
-	treasuryClient "terra/x/oracle/client"
+	treasuryClient "terra/x/treasury/client"
 
 	dist "github.com/cosmos/cosmos-sdk/x/distribution/client/rest"
 	staking "github.com/cosmos/cosmos-sdk/x/staking/client/rest"


### PR DESCRIPTION
In "terra/cmd/terracli/main.go", treasuryClient has to reference "terra/x/treasury/client" not "terra/x/oracle/client".

Issue #25 