### PR TITLE
Invalid ssl common name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![CircleCI](https://circleci.com/gh/terra-project/core/tree/develop.svg?style=svg&circle-token=9d02a374fccebf599abb8ae363c30e33d45acc6d)](https://circleci.com/gh/terra-project/core/tree/develop)
 
-**[The Terra Protocol](https://www.terra.money)** facilitates the creation of digital assets _Terra_ that track the value of major fiat currencies.
+**[The Terra Protocol](https://terra.money)** facilitates the creation of digital assets _Terra_ that track the value of major fiat currencies.
 
 **Key features:**
 


### PR DESCRIPTION
When i click "The terra protocol" link, `NET::ERR_CERT_COMMON_NAME_INVALID` error occurred.
Since your common name in ssl cert is `terra.money`, you have to remove `www` from the link.