### PR TITLE
recovering testnet.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ build-docker-terradnode:
 
 # Run a 4-node testnet locally
 localnet-start: localnet-stop
-	@if ! [ -f build/node0/terrad/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/terrad:Z tendermint/terradnode testnet --v 5 -o . --starting-ip-address 192.168.10.2  --faucet terra1pw8nf7k4p26wtam3agpggfwte0vfeaekf9n5wz --faucet-coins 10000000000mluna,10000000000mterra,100000000musd,100000000mkrw; fi
+	@if ! [ -f build/node0/terrad/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/terrad:Z tendermint/terradnode testnet --v 5 -o . --starting-ip-address 192.168.10.2; fi
 	# replace docker ip to local port, mapped
 	sed -i -e 's/192.168.10.2:26656/localhost:26656/g; s/192.168.10.3:26656/localhost:26659/g; s/192.168.10.4:26656/localhost:26661/g; s/192.168.10.5:26656/localhost:26663/g' $(CURDIR)/build/node4/terrad/config/config.toml
 	# change allow duplicated ip option to prevent the error : cant not route ~

--- a/cmd/init/testnet.go
+++ b/cmd/init/testnet.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	"github.com/cosmos/cosmos-sdk/client/keys"
 
@@ -41,11 +40,6 @@ var (
 	flagNodeDaemonHome    = "node-daemon-home"
 	flagNodeCliHome       = "node-cli-home"
 	flagStartingIPAddress = "starting-ip-address"
-
-	flagPredefinedNodes = "predefined-nodes"
-
-	flagFaucet      = "faucet"
-	flagFaucetCoins = "faucet-coins"
 )
 
 const nodeDirPerm = 0755
@@ -95,64 +89,17 @@ Example:
 		server.FlagMinGasPrices, fmt.Sprintf("600000.0%s", assets.MicroLunaDenom),
 		"Minimum gas prices to accept for transactions; All fees in a tx must meet this minimum (e.g. 0.01photino,0.001stake)",
 	)
-	cmd.Flags().String(flagPredefinedNodes, "",
-		"Predefined node list, using this will override --starting-ip-address, --node-dir-prefix and --v (ex. \"node101@192.168.0.1,node102@192.168.0.22,node103@192.168.0.56\")")
-
-	cmd.Flags().String(flagFaucet, "",
-		"Faucet address")
-	cmd.Flags().String(flagFaucetCoins, "",
-		"Coins to add to faucet account")
 
 	return cmd
 }
 
-// no-lint
-type Node struct {
-	Name string
-	IP   string
-}
-
-func makeNodes() ([]Node, error) {
-	predefined := viper.GetString(flagPredefinedNodes)
-
-	if len(predefined) > 0 {
-		// parse predefined nodes information
-		re, _ := regexp.Compile(`[\s,]*(\w+)@([\d.]+)[\s,]*`)
-		groups := re.FindAllStringSubmatch(viper.GetString(flagPredefinedNodes), -1)
-
-		nodes := make([]Node, len(groups))
-		for i, item := range groups {
-			nodes[i] = Node{item[1], item[2]}
-		}
-
-		return nodes, nil
-	}
-
-	// manipulate names & ips from startingIPAddress
-	startingIPAddr := viper.GetString(flagStartingIPAddress)
-	NumValidators := viper.GetInt(flagNumValidators)
-
-	nodes := make([]Node, NumValidators)
-	for i := 0; i < NumValidators; i++ {
-		ip, err := calculateIP(startingIPAddr, i)
-		if err != nil {
-			return nil, err
-		}
-		nodes[i] = Node{fmt.Sprintf("%s%d", viper.GetString(flagNodeDirPrefix), i), ip}
-	}
-	return nodes, nil
-}
-
 func initTestnet(config *tmconfig.Config, cdc *codec.Codec) error {
-	nodes, err := makeNodes()
-	if err != nil {
-		return err
-	}
+	var chainID string
 
 	outDir := viper.GetString(flagOutputDir)
-	numValidators := len(nodes)
+	numValidators := viper.GetInt(flagNumValidators)
 
-	chainID := viper.GetString(client.FlagChainID)
+	chainID = viper.GetString(client.FlagChainID)
 	if chainID == "" {
 		chainID = "chain-" + cmn.RandStr(6)
 	}
@@ -171,7 +118,7 @@ func initTestnet(config *tmconfig.Config, cdc *codec.Codec) error {
 
 	// generate private keys, node IDs, and initial transactions
 	for i := 0; i < numValidators; i++ {
-		nodeDirName := nodes[i].Name
+		nodeDirName := fmt.Sprintf("%s%d", viper.GetString(flagNodeDirPrefix), i)
 		nodeDaemonHomeName := viper.GetString(flagNodeDaemonHome)
 		nodeCliHomeName := viper.GetString(flagNodeCliHome)
 		nodeDir := filepath.Join(outDir, nodeDirName, nodeDaemonHomeName)
@@ -195,7 +142,12 @@ func initTestnet(config *tmconfig.Config, cdc *codec.Codec) error {
 		monikers = append(monikers, nodeDirName)
 		config.Moniker = nodeDirName
 
-		ip := nodes[i].IP
+		ip, err := getIP(i, viper.GetString(flagStartingIPAddress))
+		if err != nil {
+			_ = os.RemoveAll(outDir)
+			return err
+		}
+
 		nodeIDs[i], valPubKeys[i], err = InitializeNodeValidatorFiles(config)
 		if err != nil {
 			_ = os.RemoveAll(outDir)
@@ -205,20 +157,17 @@ func initTestnet(config *tmconfig.Config, cdc *codec.Codec) error {
 		memo := fmt.Sprintf("%s@%s:26656", nodeIDs[i], ip)
 		genFiles = append(genFiles, config.GenesisFile())
 
-		keyPass := ""
-		if !viper.IsSet(flagPredefinedNodes) {
-			buf := client.BufferStdin()
-			prompt := fmt.Sprintf(
-				"Password for account '%s' (default %s):", nodeDirName, app.DefaultKeyPass,
-			)
+		buf := client.BufferStdin()
+		prompt := fmt.Sprintf(
+			"Password for account '%s' (default %s):", nodeDirName, app.DefaultKeyPass,
+		)
 
-			keyPass, err = client.GetPassword(prompt, buf)
-			if err != nil && keyPass != "" {
-				// An error was returned that either failed to read the password from
-				// STDIN or the given password is not empty but failed to meet minimum
-				// length requirements.
-				return err
-			}
+		keyPass, err := client.GetPassword(prompt, buf)
+		if err != nil && keyPass != "" {
+			// An error was returned that either failed to read the password from
+			// STDIN or the given password is not empty but failed to meet minimum
+			// length requirements.
+			return err
 		}
 
 		if keyPass == "" {
@@ -293,32 +242,13 @@ func initTestnet(config *tmconfig.Config, cdc *codec.Codec) error {
 		srvconfig.WriteConfigFile(terraConfigFilePath, terraConfig)
 	}
 
-	// add faucet account
-	faucet := viper.GetString(flagFaucet)
-	if faucet != "" {
-		faucetAddr, err := sdk.AccAddressFromBech32(faucet)
-		if err != nil {
-			return err
-		}
-		faucetCoins, err := sdk.ParseCoins(viper.GetString(flagFaucetCoins))
-		if err != nil {
-			return err
-		}
-		faucetCoins.Sort()
-
-		accs = append(accs, app.GenesisAccount{
-			Address: faucetAddr,
-			Coins:   faucetCoins,
-		})
-	}
-
 	if err := initGenFiles(cdc, chainID, accs, genFiles, numValidators); err != nil {
 		return err
 	}
 
-	err = collectGenFiles(
+	err := collectGenFiles(
 		cdc, config, chainID, monikers, nodeIDs, valPubKeys, numValidators,
-		outDir, nodes, viper.GetString(flagNodeDaemonHome),
+		outDir, viper.GetString(flagNodeDirPrefix), viper.GetString(flagNodeDaemonHome),
 	)
 	if err != nil {
 		return err
@@ -360,14 +290,14 @@ func initGenFiles(
 func collectGenFiles(
 	cdc *codec.Codec, config *tmconfig.Config, chainID string,
 	monikers, nodeIDs []string, valPubKeys []crypto.PubKey,
-	numValidators int, outDir string, nodes []Node, nodeDaemonHomeName string,
+	numValidators int, outDir, nodeDirPrefix, nodeDaemonHomeName string,
 ) error {
 
 	var appState json.RawMessage
 	genTime := tmtime.Now()
 
 	for i := 0; i < numValidators; i++ {
-		nodeDirName := nodes[i].Name
+		nodeDirName := fmt.Sprintf("%s%d", nodeDirPrefix, i)
 		nodeDir := filepath.Join(outDir, nodeDirName, nodeDaemonHomeName)
 		gentxsDir := filepath.Join(outDir, "gentxs")
 		moniker := monikers[i]
@@ -403,6 +333,27 @@ func collectGenFiles(
 	}
 
 	return nil
+}
+
+func getIP(i int, startingIPAddr string) (string, error) {
+	var (
+		ip  string
+		err error
+	)
+
+	if len(startingIPAddr) == 0 {
+		ip, err = server.ExternalIP()
+		if err != nil {
+			return "", err
+		}
+	} else {
+		ip, err = calculateIP(startingIPAddr, i)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return ip, nil
 }
 
 func writeFile(name string, dir string, contents []byte) error {


### PR DESCRIPTION
Now, we don't need to use a customized "testnet" command to support remote-net anymore.
"testnet" command is reverted to the original rule which is supporting local-net only.