### PR TITLE
Rename 'terra' to 'core' in src path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 defaults: &linux_defaults
-  working_directory: /go/src/terra
+  working_directory: /go/src/core
   docker:
     - image: circleci/golang:1.11.5
   environment:
@@ -89,7 +89,7 @@ jobs:
           docker push ${AWS_ECR_URL}/${AWS_RESOURCE_NAME_PREFIX}:${TERRA_VERSION}
 
   localnet:
-    working_directory: /home/circleci/.go_workspace/src/terra
+    working_directory: /home/circleci/.go_workspace/src/core
     machine:
       image: circleci/classic:latest
     environment:


### PR DESCRIPTION
A try to fix a bug where ci was broken.

Not sure, but it seems like to happen when the name of the repository in Makefile is different from the name of the local source directory: `fatal: No names found, cannot describe anything.`

It would be nice if anyone could merge this pr ASAP.