### PR TITLE
remove get_vendor_deps reference from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 # Install minimum necessary dependencies, build Cosmos SDK, remove packages
 RUN apk add --no-cache $PACKAGES && \
     make get_tools && \
-    make get_vendor_deps && \
+    make go-mod-cache && \
     make build-linux && \
     make install
 


### PR DESCRIPTION
Currently circleci breaks with

`make: *** No rule to make target 'get_vendor_deps'.  Stop.` 

Removing get_vendor_deps reference from Dockerfile to solve this issue. 