### PR TITLE
Fix broken things in Dockerfile & Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY . .
 # Install minimum necessary dependencies, build Cosmos SDK, remove packages
 RUN apk add --no-cache $PACKAGES && \
     make get_tools && \
+    make go-mod-cache && \
     make build-linux && \
     make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ COPY . .
 # Install minimum necessary dependencies, build Cosmos SDK, remove packages
 RUN apk add --no-cache $PACKAGES && \
     make get_tools && \
-    make get_vendor_deps && \
     make build-linux && \
     make install
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PACKAGES_NOSIMULATION=$(shell go list ./... | grep -v '/simulation')
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
-VERSION := $(subst v,,$(shell git describe --tags --long))
+VERSION := $(subst v,,$(shell git describe --tags --always))
 BUILD_TAGS = netgo
 BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags "-X github.com/terra-project/core/version.Version=${VERSION} -X terra/version.Version=${VERSION}"
 LEDGER_ENABLED ?= true
@@ -53,7 +53,7 @@ build-linux:
 update_terra_lite_docs:
 	@statik -src=client/lcd/swagger-ui -dest=client/lcd -f
 
-install: update_terra_lite_docs 
+install: update_terra_lite_docs
 	go install $(BUILD_FLAGS) ./cmd/terrad
 	go install $(BUILD_FLAGS) ./cmd/terracli
 	go install $(BUILD_FLAGS) ./cmd/terrakeyutil


### PR DESCRIPTION
As @bluedisk said, fixed a broken target (which is get_vendor_deps) in Dockerfile, and also fixed `VERSION` variable in Makefile since we're not use `tags` in every build. 

I would also recommend to use semantic versioning for `tags`. Let's have a more talks later, or you might take a look at [this](https://egghead.io/lessons/tools-practical-git-use-semantic-versioning-with-git-tag))