### PR TITLE
Fix installation guide instructions; add $GOPATH

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,7 +4,7 @@ This guide will explain how to install the `terrad` and `terracli` entrypoints o
 
 ### Install Go
 
-Install `go` by following the [official docs](https://golang.org/doc/install). 
+Install `go` by following the [official docs](https://golang.org/doc/install).
 
 ::: tip
 **Go 1.12+ +** is required for Terra Core.
@@ -17,8 +17,8 @@ If necessary, make sure you `git checkout` the correct
 [released version](https://github.com/terra-project/core//releases).
 
 ```bash
-git clone https://github.com/terra-project/core/
-git checkout master
+git clone https://github.com/terra-project/core/ $GOPATH/src/github.com/terra-project/core
+git checkout master # as of 2019.04.11 only `develop` branch builds correctly
 make
 ```
 


### PR DESCRIPTION
edit path to `git clone` to; add note about proper branch to use before building with `make`.

If you simply `git clone https://github.com/terra-project/core`, only the folder `core` will be created locally; but you actually need the folders `../terra-project/core` to be created in your `$GOPATH` for the relevant dependencies to be downloaded and found by `terra-project/core`...