### PR TITLE
Fix version info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,10 +101,10 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.11.5
     steps:
       - checkout
-      - run: curl -sL https://git.io/goreleaser | bash
+      - run: BUILD_TAGS="netgo ledger" GOSUM=$(sha256sum go.sum | cut -d ' ' -f1) curl -sL https://git.io/goreleaser | bash
 
   upload_coverage:
     <<: *linux_defaults

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,14 +2,23 @@ project_name: terra
 
 before:
   hooks:
-    - go mod download
-    - go generate ./...
+    - make get_tools
+    - make go-mod-cache
 
 builds:
   -
     main: cmd/terracli/main.go
     binary: terracli
-    ldflags: -s -w -X main.version={{.Version}}
+    asmflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    gcflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    ldflags: |
+      -s -w
+      -X github.com/terra-project/core/version.Version={{.Version}}
+      -X github.com/terra-project/core/version.Commit={{.Commit}}
+      -X "github.com/terra-project/core/version.BuildTags={{.Env.BUILD_TAGS}}"
+      -X github.com/terra-project/core/version.GoSumHash={{.Env.GOSUM}}
     env:
       - GO111MODULE=on
       - CGO_ENABLED=0
@@ -28,7 +37,16 @@ builds:
   -
     main: cmd/terrad/main.go
     binary: terrad
-    ldflags: -s -w -X main.version={{.Version}}
+    asmflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    gcflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    ldflags: |
+      -s -w
+      -X github.com/terra-project/core/version.Version={{.Version}}
+      -X github.com/terra-project/core/version.Commit={{.Commit}}
+      -X "github.com/terra-project/core/version.BuildTags={{.Env.BUILD_TAGS}}"
+      -X github.com/terra-project/core/version.GoSumHash={{.Env.GOSUM}}
     env:
       - GO111MODULE=on
       - CGO_ENABLED=0
@@ -47,7 +65,16 @@ builds:
   -
     main: cmd/terrakeyutil/main.go
     binary: terrakeytutil
-    ldflags: -s -w -X main.version={{.Version}}
+    asmflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    gcflags:
+      - all=-trimpath={{.Env.GOPATH}}
+    ldflags: |
+      -s -w
+      -X github.com/terra-project/core/version.Version={{.Version}}
+      -X github.com/terra-project/core/version.Commit={{.Commit}}
+      -X "github.com/terra-project/core/version.BuildTags={{.Env.BUILD_TAGS}}"
+      -X github.com/terra-project/core/version.GoSumHash={{.Env.GOSUM}}
     env:
       - GO111MODULE=on
       - CGO_ENABLED=0

--- a/version/command.go
+++ b/version/command.go
@@ -24,7 +24,7 @@ var (
 			verInfo := newVersionInfo()
 
 			if !viper.GetBool(flagLong) {
-				fmt.Println(verInfo.CosmosSDK)
+				fmt.Println(verInfo.Core)
 				return nil
 			}
 

--- a/version/version.go
+++ b/version/version.go
@@ -8,33 +8,33 @@ import (
 
 // Variables set by build flags
 var (
-	Commit        = ""
-	Version       = ""
-	VendorDirHash = ""
-	BuildTags     = ""
+	Commit    = ""
+	Version   = ""
+	GoSumHash = ""
+	BuildTags = ""
 )
 
 type versionInfo struct {
-	CosmosSDK     string `json:"cosmos_sdk"`
-	GitCommit     string `json:"commit"`
-	VendorDirHash string `json:"vendor_hash"`
-	BuildTags     string `json:"build_tags"`
-	GoVersion     string `json:"go"`
+	Core      string `json:"core"`
+	GitCommit string `json:"commit"`
+	GoSumHash string `json:"gosum_hash"`
+	BuildTags string `json:"build_tags"`
+	GoVersion string `json:"go"`
 }
 
 func (v versionInfo) String() string {
-	return fmt.Sprintf(`cosmos-sdk: %s
+	return fmt.Sprintf(`core: %s
 git commit: %s
-vendor hash: %s
+go.sum hash: %s
 build tags: %s
-%s`, v.CosmosSDK, v.GitCommit, v.VendorDirHash, v.BuildTags, v.GoVersion)
+%s`, v.Core, v.GitCommit, v.GoSumHash, v.BuildTags, v.GoVersion)
 }
 
 func newVersionInfo() versionInfo {
 	return versionInfo{
 		Version,
 		Commit,
-		VendorDirHash,
+		GoSumHash,
 		BuildTags,
 		fmt.Sprintf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)}
 }


### PR DESCRIPTION
Fixed the `version` command in `terrad` cli:

```
$ terrad version --long
core: 0.0.7
git commit: 5f4f08d2ea4de66f9d52a166249678cc1ecc9990
go.sum hash: 2bbcf2782c3fd73c1a2997b2c825b4c3a40646979153ab4ae639dfb027083ab5
build tags: netgo ledger
go version go1.12 darwin/amd64
```

The new version can be defined after tagging (e.g. `git tag v0.x.x`) and will be released with CI.