### PR TITLE
add min self delegation flag to create_validator command

### DIFF
--- a/docs/guide/validators.md
+++ b/docs/guide/validators.md
@@ -38,7 +38,8 @@ terracli tx staking create-validator \
   --from=<key_name> \
   --commission-rate="0.10" \
   --commission-max-rate="0.20" \
-  --commission-max-change-rate="0.01" 
+  --commission-max-change-rate="0.01" \
+  --min-self-delegation=1
 ```
 
 __Note__: When specifying commission parameters, the `commission-max-change-rate`


### PR DESCRIPTION
The create-validator cli command doesn't work without the mindelegation flag. editing docs to fix. 