### PR TITLE
Bugfix/cli currency filter

### DIFF
--- a/x/market/client/cli/tx.go
+++ b/x/market/client/cli/tx.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"github.com/terra-project/core/types/assets"
 	"github.com/terra-project/core/x/market"
 	"strings"
 
@@ -40,10 +39,6 @@ $ terracli market swap --offer-coin="1000krw" --ask-denom="usd"
 			askDenom := viper.GetString(flagAskDenom)
 			if len(askDenom) == 0 {
 				return fmt.Errorf("--ask-denom flag is required")
-			}
-
-			if !assets.IsValidDenom(askDenom) {
-				return fmt.Errorf("The denom is not known: %s", askDenom)
 			}
 
 			offerCoinStr := viper.GetString(flagOfferCoin)

--- a/x/market/client/rest/tx.go
+++ b/x/market/client/rest/tx.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/terra-project/core/types/assets"
 	"github.com/terra-project/core/x/market"
 
 	clientrest "github.com/cosmos/cosmos-sdk/client/rest"
@@ -35,12 +34,6 @@ func submitSwapHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.Handl
 		var req SwapReq
 		if !rest.ReadRESTReq(w, r, cdc, &req) {
 			err := sdk.ErrUnknownRequest("malformed request")
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		if !assets.IsValidDenom(req.AskDenom) {
-			err := fmt.Errorf("The denom is not known: %s", req.AskDenom)
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}


### PR DESCRIPTION
Removed currency whitelist check from market/client/cli and market/client/rest. 

Now you can swap coins even if they are not predefined in types/assets.go. 

