### PR TITLE
Changing micro currency units from m-asset to u-asset

### DIFF
--- a/cmd/init/testnet.go
+++ b/cmd/init/testnet.go
@@ -87,7 +87,7 @@ Example:
 	)
 	cmd.Flags().String(
 		server.FlagMinGasPrices, fmt.Sprintf("0.015%s,0.015%s,0.015%s,0.015%s,0.015%s,0.015%s,0.015%s,0.015%s", assets.MicroLunaDenom, assets.MicroSDRDenom, assets.MicroUSDDenom, assets.MicroKRWDenom, assets.MicroCNYDenom, assets.MicroJPYDenom, assets.MicroEURDenom, assets.MicroGBPDenom),
-		"Minimum gas prices to accept for transactions; All fees in a tx must meet this minimum (e.g. 0.01mluna,0.01msdr)",
+		"Minimum gas prices to accept for transactions; All fees in a tx must meet this minimum (e.g. 0.01uluna,0.01usdr)",
 	)
 
 	return cmd

--- a/docs/guide/deploy-testnet.md
+++ b/docs/guide/deploy-testnet.md
@@ -34,10 +34,10 @@ terracli keys add validator
 # Add that key into the genesis.app_state.accounts array in the genesis file
 # NOTE: this command lets you set the number of coins. Make sure this account has some coins
 # with the genesis.app_state.staking.params.bond_denom denom, the default is staking
-terrad add-genesis-account $(terracli keys show validator -a) 1000mluna,1000msdr
+terrad add-genesis-account $(terracli keys show validator -a) 1000uluna,1000usdr
 
 # Generate the transaction that creates your validator
-terrad gentx --name validator --amount 100mluna
+terrad gentx --name validator --amount 100uluna
 
 # Add the generated bonding transaction to the genesis file
 terrad collect-gentxs

--- a/docs/guide/terracli.md
+++ b/docs/guide/terracli.md
@@ -129,13 +129,13 @@ higher tx priority.
 e.g.
 
 ```bash
-terracli tx send ... --fees=100msdr
+terracli tx send ... --fees=100usdr
 ```
 
 or
 
 ```bash
-terracli tx send ... --gas-prices=0.000001msdr
+terracli tx send ... --gas-prices=0.000001usdr
 ```
 
 ### Account

--- a/docs/guide/validators.md
+++ b/docs/guide/validators.md
@@ -31,7 +31,7 @@ Don't use more Luna than you have! You can always get more by using the [Faucet]
 
 ```bash
 terracli tx staking create-validator \
-  --amount=5000000mluna \
+  --amount=5000000uluna \
   --pubkey=$(terrad tendermint show-validator) \
   --moniker="choose a moniker" \
   --chain-id=<chain_id> \

--- a/types/assets/assets.go
+++ b/types/assets/assets.go
@@ -2,14 +2,14 @@ package assets
 
 //nolint
 const (
-	MicroLunaDenom = "mluna"
-	MicroUSDDenom  = "musd"
-	MicroKRWDenom  = "mkrw"
-	MicroSDRDenom  = "msdr"
-	MicroCNYDenom  = "mcny"
-	MicroJPYDenom  = "mjpy"
-	MicroEURDenom  = "meur"
-	MicroGBPDenom  = "mgbp"
+	MicroLunaDenom = "uluna"
+	MicroUSDDenom  = "uusd"
+	MicroKRWDenom  = "ukrw"
+	MicroSDRDenom  = "usdr"
+	MicroCNYDenom  = "ucny"
+	MicroJPYDenom  = "ujpy"
+	MicroEURDenom  = "ueur"
+	MicroGBPDenom  = "ugbp"
 
 	MicroUnit = int64(1e6)
 )

--- a/x/market/client/cli/tx.go
+++ b/x/market/client/cli/tx.go
@@ -81,7 +81,7 @@ $ terracli market swap --offer-coin="1000krw" --ask-denom="usd"
 		},
 	}
 
-	cmd.Flags().String(flagOfferCoin, "", "The asset to swap from e.g. 1000mkrw")
+	cmd.Flags().String(flagOfferCoin, "", "The asset to swap from e.g. 1000ukrw")
 	cmd.Flags().String(flagAskDenom, "", "Denom of the asset to swap to")
 
 	return cmd

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -29,7 +29,7 @@ func GetCmdQueryPrice(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		Long: strings.TrimSpace(`
 Query the current price of a denom asset. You can find the current list of active denoms by running: terracli query oracle active
 
-$ terracli query oracle price --denom mkrw
+$ terracli query oracle price --denom ukrw
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -89,9 +89,9 @@ func GetCmdQueryVotes(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		Long: strings.TrimSpace(`
 Query outstanding oracle votes, filtered by denom and voter address.
 
-$ terracli query oracle votes --denom="musd" --voter="terrad8duyufdshs..."
+$ terracli query oracle votes --denom="uusd" --voter="terrad8duyufdshs..."
 
-returns oracle votes submitted by terrad8duyufdshs... for denom musd 
+returns oracle votes submitted by terrad8duyufdshs... for denom uusd 
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -29,9 +29,9 @@ func GetCmdPriceVote(cdc *codec.Codec) *cobra.Command {
 		Long: strings.TrimSpace(`
 Submit an oracle vote for the price of Luna denominated in the input denom.
 
-$ terracli oracle vote --denom "mkrw" --price "8890" --from mykey
+$ terracli oracle vote --denom "ukrw" --price "8890" --from mykey
 
-where "mkrw" is the denominating currency, and "8890" is the price of micro Luna in micro KRW from the voter's point of view. 
+where "ukrw" is the denominating currency, and "8890" is the price of micro Luna in micro KRW from the voter's point of view. 
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/x/treasury/client/cli/query.go
+++ b/x/treasury/client/cli/query.go
@@ -74,7 +74,7 @@ func GetCmdQueryTaxCap(cdc *codec.Codec) *cobra.Command {
 Query the current stability tax cap of the denom asset. 
 The stability tax levied on a tx is at most tax cap, regardless of the size of the transaction. 
 
-$ terracli query treasury taxcap --denom="mkrw"
+$ terracli query treasury taxcap --denom="ukrw"
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -112,7 +112,7 @@ func GetCmdQueryIssuance(cdc *codec.Codec) *cobra.Command {
 		Long: strings.TrimSpace(`
 Query the current issuance of a denom asset. 
 
-$ terracli query treasury issuance --denom="mkrw"
+$ terracli query treasury issuance --denom="ukrw"
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)


### PR DESCRIPTION
## Summary 

Currently, on-chain assets were defined as "musd" "mluna" for 10^-6 th of the parent asset. For micro units, the convention is to prefix 'u' instead of 'm'

https://en.wikipedia.org/wiki/International_System_of_Units#Prefixes

## Fix

Changed all asset prefixes to 'u' instead of 'm'.

- [x] passes all tests
- [x] documentation updated