### PR TITLE
Implemented graded vesting accounts for Terra genesis

### DIFF
--- a/cmd/init/testnet.go
+++ b/cmd/init/testnet.go
@@ -87,7 +87,7 @@ Example:
 	)
 	cmd.Flags().String(
 		server.FlagMinGasPrices, fmt.Sprintf("0.015%s,0.015%s,0.015%s,0.015%s,0.015%s,0.015%s,0.015%s,0.015%s", assets.MicroLunaDenom, assets.MicroSDRDenom, assets.MicroUSDDenom, assets.MicroKRWDenom, assets.MicroCNYDenom, assets.MicroJPYDenom, assets.MicroEURDenom, assets.MicroGBPDenom),
-		"Minimum gas prices to accept for transactions; All fees in a tx must meet this minimum (e.g. 0.01mluna,0.01msdr)",
+		"Minimum gas prices to accept for transactions; All fees in a tx must meet this minimum (e.g. 0.01uluna,0.01usdr)",
 	)
 
 	return cmd

--- a/docs/guide/deploy-testnet.md
+++ b/docs/guide/deploy-testnet.md
@@ -34,10 +34,10 @@ terracli keys add validator
 # Add that key into the genesis.app_state.accounts array in the genesis file
 # NOTE: this command lets you set the number of coins. Make sure this account has some coins
 # with the genesis.app_state.staking.params.bond_denom denom, the default is staking
-terrad add-genesis-account $(terracli keys show validator -a) 1000mluna,1000msdr
+terrad add-genesis-account $(terracli keys show validator -a) 1000uluna,1000usdr
 
 # Generate the transaction that creates your validator
-terrad gentx --name validator --amount 100mluna
+terrad gentx --name validator --amount 100uluna
 
 # Add the generated bonding transaction to the genesis file
 terrad collect-gentxs

--- a/docs/guide/terracli.md
+++ b/docs/guide/terracli.md
@@ -129,13 +129,13 @@ higher tx priority.
 e.g.
 
 ```bash
-terracli tx send ... --fees=100msdr
+terracli tx send ... --fees=100usdr
 ```
 
 or
 
 ```bash
-terracli tx send ... --gas-prices=0.000001msdr
+terracli tx send ... --gas-prices=0.000001usdr
 ```
 
 ### Account

--- a/docs/guide/validators.md
+++ b/docs/guide/validators.md
@@ -31,7 +31,7 @@ Don't use more Luna than you have! You can always get more by using the [Faucet]
 
 ```bash
 terracli tx staking create-validator \
-  --amount=5000000mluna \
+  --amount=5000000uluna \
   --pubkey=$(terrad tendermint show-validator) \
   --moniker="choose a moniker" \
   --chain-id=<chain_id> \

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/types/assets/assets.go
+++ b/types/assets/assets.go
@@ -2,14 +2,14 @@ package assets
 
 //nolint
 const (
-	MicroLunaDenom = "mluna"
-	MicroUSDDenom  = "musd"
-	MicroKRWDenom  = "mkrw"
-	MicroSDRDenom  = "msdr"
-	MicroCNYDenom  = "mcny"
-	MicroJPYDenom  = "mjpy"
-	MicroEURDenom  = "meur"
-	MicroGBPDenom  = "mgbp"
+	MicroLunaDenom = "uluna"
+	MicroUSDDenom  = "uusd"
+	MicroKRWDenom  = "ukrw"
+	MicroSDRDenom  = "usdr"
+	MicroCNYDenom  = "ucny"
+	MicroJPYDenom  = "ujpy"
+	MicroEURDenom  = "ueur"
+	MicroGBPDenom  = "ugbp"
 
 	MicroUnit = int64(1e6)
 )

--- a/types/graded_account.go
+++ b/types/graded_account.go
@@ -1,0 +1,228 @@
+package types
+
+import (
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+)
+
+//-----------------------------------------------------------------------------
+// Vesting Schedule
+
+// VestingSchedule maps the ratio of tokens that becomes vested by blocktime (in nanoseconds) from genesis.
+// The sum of values in the Schedule should sum to 1.0.
+// CONTRACT: assumes that entries are
+type VestingSchedule struct {
+	Schedule map[int64]sdk.Dec `json:"vesting_schedule"` // maps blocktime to percentage vested. Should sum to 1.
+}
+
+// NewVestingSchedule creates a new vesting schedule instance.
+func NewVestingSchedule(schedule map[int64]sdk.Dec) VestingSchedule {
+	return VestingSchedule{
+		Schedule: schedule,
+	}
+}
+
+// GetVestedRatio returns the ratio of tokens that have vested by blockTime.
+func (vs VestingSchedule) GetVestedRatio(blockTime int64) sdk.Dec {
+	sumRatio := sdk.ZeroDec()
+	for cliff, ratio := range vs.Schedule {
+		if blockTime >= cliff {
+			sumRatio = sumRatio.Add(ratio)
+		}
+	}
+	return sumRatio
+}
+
+// IsValid checks that the vestingschedule is valid.
+func (vs VestingSchedule) IsValid() bool {
+	sumRatio := sdk.ZeroDec()
+	for time, vestRatio := range vs.Schedule {
+		if time < 0 || vestRatio.LTE(sdk.ZeroDec()) {
+			return false
+		}
+
+		sumRatio = sumRatio.Add(vestRatio)
+	}
+
+	return sumRatio.Equal(sdk.OneDec())
+}
+
+// String implements the fmt.Stringer interface
+func (vs VestingSchedule) String() string {
+	return fmt.Sprintf(`VestingSchedule: %v`, vs.Schedule)
+}
+
+//-----------------------------------------------------------------------------
+// Graded Vesting Account
+
+// GradedVestingAccount implements the VestingAccount interface. It vests all
+// coins according to a predefined schedule.
+var _ auth.VestingAccount = (*GradedVestingAccount)(nil)
+
+// GradedVestingAccount implements the VestingAccount interface. It vests tokens according to
+// a predefined set of vesting cliffs.
+type GradedVestingAccount struct {
+	*auth.BaseVestingAccount
+
+	Schedules map[string]VestingSchedule
+}
+
+// NewGradedVestingAccount returns a GradedVestingAccount
+func NewGradedVestingAccount(baseAcc *auth.BaseAccount, schedules map[string]VestingSchedule) *GradedVestingAccount {
+	baseVestingAcc := &auth.BaseVestingAccount{
+		BaseAccount:     baseAcc,
+		OriginalVesting: baseAcc.Coins,
+		EndTime:         0,
+	}
+
+	return &GradedVestingAccount{baseVestingAcc, schedules}
+}
+
+// GetSchedules returns the VestingSchedules of the graded vesting account
+func (gva GradedVestingAccount) GetSchedules() map[string]VestingSchedule {
+	return gva.Schedules
+}
+
+// GetVestedCoins returns the total amount of vested coins for a graded vesting
+// account. All coins are only vested once the schedule has elapsed.
+func (gva GradedVestingAccount) GetVestedCoins(blockTime time.Time) sdk.Coins {
+	var vestedCoins sdk.Coins
+	for _, ovc := range gva.OriginalVesting {
+		if schedule, exists := gva.Schedules[ovc.Denom]; exists {
+			vestedRatio := schedule.GetVestedRatio(blockTime.Unix())
+			vestedAmt := ovc.Amount.ToDec().Mul(vestedRatio).RoundInt()
+			if vestedAmt.Equal(sdk.ZeroInt()) {
+				continue
+			}
+			vestedCoins = append(vestedCoins, sdk.NewCoin(ovc.Denom, vestedAmt))
+		} else {
+			vestedCoins = append(vestedCoins, sdk.NewCoin(ovc.Denom, ovc.Amount))
+		}
+	}
+
+	return vestedCoins
+}
+
+// GetVestingCoins returns the total number of vesting coins for a graded
+// vesting account.
+func (gva GradedVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coins {
+	return gva.OriginalVesting.Sub(gva.GetVestedCoins(blockTime))
+}
+
+// SpendableCoins returns the total number of spendable coins for a graded
+// vesting account.
+func (gva GradedVestingAccount) SpendableCoins(blockTime time.Time) sdk.Coins {
+	return gva.spendableCoins(gva.GetVestingCoins(blockTime))
+}
+
+// TrackDelegation tracks a desired delegation amount by setting the appropriate
+// values for the amount of delegated vesting, delegated free, and reducing the
+// overall amount of base coins.
+func (gva *GradedVestingAccount) TrackDelegation(blockTime time.Time, amount sdk.Coins) {
+	gva.trackDelegation(gva.GetVestingCoins(blockTime), amount)
+}
+
+// GetStartTime returns zero since a graded vesting account has no start time.
+func (gva *GradedVestingAccount) GetStartTime() int64 {
+	return 0
+}
+
+// GetEndTime returns the time when vesting ends for a graded vesting account.
+func (gva *GradedVestingAccount) GetEndTime() int64 {
+	return 0
+}
+
+func (gva GradedVestingAccount) String() string {
+	var pubkey string
+
+	if gva.PubKey != nil {
+		pubkey = sdk.MustBech32ifyAccPub(gva.PubKey)
+	}
+
+	return fmt.Sprintf(`Graded Vesting Account:
+  Address:          %s
+  Pubkey:           %s
+  Coins:            %s
+  AccountNumber:    %d
+  Sequence:         %d
+  OriginalVesting:  %s
+  DelegatedFree:    %s
+  DelegatedVesting: %s
+  Schedules:        %v `,
+		gva.Address, pubkey, gva.Coins, gva.AccountNumber, gva.Sequence,
+		gva.OriginalVesting, gva.DelegatedFree, gva.DelegatedVesting,
+		gva.Schedules,
+	)
+}
+
+// spendableCoins returns all the spendable coins for a vesting account given a
+// set of vesting coins.
+//
+// CONTRACT: The account's coins, delegated vesting coins, vestingCoins must be
+// sorted.
+func (gva GradedVestingAccount) spendableCoins(vestingCoins sdk.Coins) sdk.Coins {
+	var spendableCoins sdk.Coins
+	bc := gva.GetCoins()
+
+	for _, coin := range bc {
+		// zip/lineup all coins by their denomination to provide O(n) time
+		baseAmt := coin.Amount
+		vestingAmt := vestingCoins.AmountOf(coin.Denom)
+		delVestingAmt := gva.DelegatedVesting.AmountOf(coin.Denom)
+
+		// compute min((BC + DV) - V, BC) per the specification
+		min := sdk.MinInt(baseAmt.Add(delVestingAmt).Sub(vestingAmt), baseAmt)
+		spendableCoin := sdk.NewCoin(coin.Denom, min)
+
+		if !spendableCoin.IsZero() {
+			spendableCoins = spendableCoins.Add(sdk.Coins{spendableCoin})
+		}
+	}
+
+	return spendableCoins
+}
+
+// trackDelegation tracks a delegation amount for any given vesting account type
+// given the amount of coins currently vesting. It returns the resulting base
+// coins.
+//
+// CONTRACT: The account's coins, delegation coins, vesting coins, and delegated
+// vesting coins must be sorted.
+func (gva *GradedVestingAccount) trackDelegation(vestingCoins, amount sdk.Coins) {
+	bc := gva.GetCoins()
+
+	for _, coin := range amount {
+		// zip/lineup all coins by their denomination to provide O(n) time
+
+		baseAmt := bc.AmountOf(coin.Denom)
+		vestingAmt := vestingCoins.AmountOf(coin.Denom)
+		delVestingAmt := gva.DelegatedVesting.AmountOf(coin.Denom)
+
+		// Panic if the delegation amount is zero or if the base coins does not
+		// exceed the desired delegation amount.
+		if coin.Amount.IsZero() || baseAmt.LT(coin.Amount) {
+			panic("delegation attempt with zero coins or insufficient funds")
+		}
+
+		// compute x and y per the specification, where:
+		// X := min(max(V - DV, 0), D)
+		// Y := D - X
+		x := sdk.MinInt(sdk.MaxInt(vestingAmt.Sub(delVestingAmt), sdk.ZeroInt()), coin.Amount)
+		y := coin.Amount.Sub(x)
+
+		if !x.IsZero() {
+			xCoin := sdk.NewCoin(coin.Denom, x)
+			gva.DelegatedVesting = gva.DelegatedVesting.Add(sdk.Coins{xCoin})
+		}
+
+		if !y.IsZero() {
+			yCoin := sdk.NewCoin(coin.Denom, y)
+			gva.DelegatedFree = gva.DelegatedFree.Add(sdk.Coins{yCoin})
+		}
+
+		gva.Coins = gva.Coins.Sub(sdk.Coins{coin})
+	}
+}

--- a/types/graded_account_test.go
+++ b/types/graded_account_test.go
@@ -1,0 +1,392 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/terra-project/core/types/assets"
+
+	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func keyPubAddr() (crypto.PrivKey, crypto.PubKey, sdk.AccAddress) {
+	key := secp256k1.GenPrivKey()
+	pub := key.PubKey()
+	addr := sdk.AccAddress(pub.Address())
+	return key, pub, addr
+}
+
+var (
+	angelSchedule        VestingSchedule
+	seedSchedule         VestingSchedule
+	privateSchedule      VestingSchedule
+	privateBonusSchedule VestingSchedule
+	employeeSchedule     VestingSchedule
+	timeGenesisString    = "2019-04-23 23:00:00 -0800 PST"
+	monthlyTimes         []int64
+	timeGenesis          time.Time
+)
+
+// initialize the times!
+func init() {
+	var err error
+	timeLayoutString := "2006-01-02 15:04:05 -0700 MST"
+	timeGenesis, err = time.Parse(timeLayoutString, timeGenesisString)
+	if err != nil {
+		panic(err)
+	}
+
+	monthlyTimes = []int64{}
+	for i := 0; i < 4; i++ {
+		for j := 0; j < 12; j++ {
+			monthlyTimes = append(monthlyTimes, timeGenesis.AddDate(i, j, 0).Unix())
+		}
+	}
+
+	angelSchedule = NewVestingSchedule(
+		map[int64]sdk.Dec{
+			monthlyTimes[1]:  sdk.NewDecWithPrec(10, 2),
+			monthlyTimes[2]:  sdk.NewDecWithPrec(10, 2),
+			monthlyTimes[3]:  sdk.NewDecWithPrec(10, 2),
+			monthlyTimes[12]: sdk.NewDecWithPrec(70, 2),
+		},
+	)
+
+	seedSchedule = NewVestingSchedule(
+		map[int64]sdk.Dec{
+			monthlyTimes[1]:  sdk.NewDecWithPrec(10, 2),
+			monthlyTimes[2]:  sdk.NewDecWithPrec(10, 2),
+			monthlyTimes[3]:  sdk.NewDecWithPrec(10, 2),
+			monthlyTimes[10]: sdk.NewDecWithPrec(70, 2),
+		},
+	)
+
+	privateSchedule = NewVestingSchedule(
+		map[int64]sdk.Dec{
+			monthlyTimes[3]: sdk.NewDecWithPrec(16, 2),
+			monthlyTimes[4]: sdk.NewDecWithPrec(17, 2),
+			monthlyTimes[5]: sdk.NewDecWithPrec(16, 2),
+			monthlyTimes[6]: sdk.NewDecWithPrec(17, 2),
+			monthlyTimes[7]: sdk.NewDecWithPrec(17, 2),
+			monthlyTimes[8]: sdk.NewDecWithPrec(17, 2),
+		},
+	)
+
+	privateBonusSchedule = NewVestingSchedule(
+		map[int64]sdk.Dec{
+			monthlyTimes[6]:  sdk.NewDecWithPrec(8, 2),
+			monthlyTimes[7]:  sdk.NewDecWithPrec(8, 2),
+			monthlyTimes[8]:  sdk.NewDecWithPrec(8, 2),
+			monthlyTimes[9]:  sdk.NewDecWithPrec(8, 2),
+			monthlyTimes[10]: sdk.NewDecWithPrec(8, 2),
+			monthlyTimes[11]: sdk.NewDecWithPrec(8, 2),
+			monthlyTimes[12]: sdk.NewDecWithPrec(8, 2),
+			monthlyTimes[13]: sdk.NewDecWithPrec(8, 2),
+			monthlyTimes[14]: sdk.NewDecWithPrec(9, 2),
+			monthlyTimes[15]: sdk.NewDecWithPrec(9, 2),
+			monthlyTimes[16]: sdk.NewDecWithPrec(9, 2),
+			monthlyTimes[17]: sdk.NewDecWithPrec(9, 2),
+		},
+	)
+
+	employeeSchedule = NewVestingSchedule(
+		map[int64]sdk.Dec{
+			monthlyTimes[0]:  sdk.NewDecWithPrec(5, 2),
+			monthlyTimes[12]: sdk.NewDecWithPrec(29, 2),
+			monthlyTimes[24]: sdk.NewDecWithPrec(33, 2),
+			monthlyTimes[36]: sdk.NewDecWithPrec(33, 2),
+		},
+	)
+}
+
+func scaleCoins(scale float64, denom string, input sdk.Coins) sdk.Coins {
+	output := sdk.Coins{}
+	for _, coin := range input {
+		if coin.Denom != denom {
+			continue
+		}
+
+		decScale := sdk.NewDecWithPrec(int64(scale*100), 2)
+		output = append(output, sdk.NewCoin(coin.Denom, decScale.MulInt(coin.Amount).RoundInt()))
+	}
+	return output
+}
+
+func TestGetVestedCoinsGradVestingAcc(t *testing.T) {
+	genesis := timeGenesis
+
+	_, _, addr := keyPubAddr()
+	origCoins := sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 10000)}
+	bacc := auth.NewBaseAccountWithAddress(addr)
+	bacc.SetCoins(origCoins)
+
+	// require no coins are vested until schedule maturation
+	gva := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	vestedCoins := gva.GetVestedCoins(genesis)
+	require.Nil(t, vestedCoins)
+
+	// require coins be vested at the expected cliff
+	vestedCoins = gva.GetVestedCoins(timeGenesis.AddDate(0, 1, 0))
+	require.Equal(t, scaleCoins(0.1, assets.MicroLunaDenom, origCoins), vestedCoins)
+
+	vestedCoins = gva.GetVestedCoins(timeGenesis.AddDate(0, 2, 0))
+	require.Equal(t, scaleCoins(0.2, assets.MicroLunaDenom, origCoins), vestedCoins)
+
+	vestedCoins = gva.GetVestedCoins(timeGenesis.AddDate(0, 3, 0))
+	require.Equal(t, scaleCoins(0.3, assets.MicroLunaDenom, origCoins), vestedCoins)
+
+	vestedCoins = gva.GetVestedCoins(timeGenesis.AddDate(0, 4, 0))
+	require.Equal(t, scaleCoins(0.3, assets.MicroLunaDenom, origCoins), vestedCoins)
+
+	vestedCoins = gva.GetVestedCoins(timeGenesis.AddDate(0, 5, 0))
+	require.Equal(t, scaleCoins(0.3, assets.MicroLunaDenom, origCoins), vestedCoins)
+
+	vestedCoins = gva.GetVestedCoins(timeGenesis.AddDate(1, 0, 0))
+	require.Equal(t, scaleCoins(1.0, assets.MicroLunaDenom, origCoins), vestedCoins)
+}
+
+func TestGetVestingCoinsGradVestingAcc(t *testing.T) {
+	genesis := timeGenesis
+
+	_, _, addr := keyPubAddr()
+	origCoins := sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 10000)}
+	bacc := auth.NewBaseAccountWithAddress(addr)
+	bacc.SetCoins(origCoins)
+
+	// require no coins are vested until schedule maturation
+	gva := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	vestingCoins := gva.GetVestingCoins(genesis)
+	require.Equal(t, vestingCoins, origCoins)
+
+	// require coins be vested at the expected cliff
+	vestingCoins = gva.GetVestingCoins(timeGenesis.AddDate(0, 1, 0))
+	require.Equal(t, origCoins.Sub(scaleCoins(0.1, assets.MicroLunaDenom, origCoins)), vestingCoins)
+
+	vestingCoins = gva.GetVestingCoins(timeGenesis.AddDate(0, 2, 0))
+	require.Equal(t, origCoins.Sub(scaleCoins(0.2, assets.MicroLunaDenom, origCoins)), vestingCoins)
+
+	vestingCoins = gva.GetVestingCoins(timeGenesis.AddDate(0, 3, 0))
+	require.Equal(t, origCoins.Sub(scaleCoins(0.3, assets.MicroLunaDenom, origCoins)), vestingCoins)
+
+	vestingCoins = gva.GetVestingCoins(timeGenesis.AddDate(0, 4, 0))
+	require.Equal(t, origCoins.Sub(scaleCoins(0.3, assets.MicroLunaDenom, origCoins)), vestingCoins)
+
+	vestingCoins = gva.GetVestingCoins(timeGenesis.AddDate(0, 5, 0))
+	require.Equal(t, origCoins.Sub(scaleCoins(0.3, assets.MicroLunaDenom, origCoins)), vestingCoins)
+
+	vestingCoins = gva.GetVestingCoins(timeGenesis.AddDate(1, 0, 0))
+	require.Equal(t, origCoins.Sub(scaleCoins(1.0, assets.MicroLunaDenom, origCoins)), vestingCoins)
+}
+
+func TestSpendableCoinsGradVestingAcc(t *testing.T) {
+	genesis := timeGenesis
+
+	_, _, addr := keyPubAddr()
+	origCoins := sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 10000), sdk.NewInt64Coin(assets.MicroSDRDenom, 10000)}
+	sdrCoins := sdk.Coins{sdk.NewInt64Coin(assets.MicroSDRDenom, 10000)}
+	bacc := auth.NewBaseAccountWithAddress(addr)
+	bacc.SetCoins(origCoins)
+
+	// require no coins are vested until schedule maturation
+	gva := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+
+	spendableCoins := gva.SpendableCoins(genesis)
+	require.Equal(t, sdrCoins, spendableCoins)
+
+	// require that all coins are spendable after the maturation of the vesting
+	// schedule
+	spendableCoins = gva.SpendableCoins(timeGenesis.AddDate(1, 0, 0))
+	require.Equal(t, origCoins, spendableCoins)
+
+	// require that all luna coins are still vesting after some time
+	spendableCoins = gva.SpendableCoins(genesis.Add(12 * time.Hour))
+	require.Equal(t, spendableCoins, sdrCoins)
+
+	// receive some coins
+	regvamt := sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 50)}
+	gva.SetCoins(gva.GetCoins().Add(regvamt))
+
+	// require that only received coins and sdrCoins are spendable since the account is still
+	// vesting
+	spendableCoins = gva.SpendableCoins(genesis.Add(12 * time.Hour))
+	require.Equal(t, regvamt.Add(sdrCoins), spendableCoins)
+
+	// spend all spendable coins
+	gva.SetCoins(gva.GetCoins().Sub(spendableCoins))
+
+	// require that no more coins are spendable
+	spendableCoins = gva.SpendableCoins(genesis.Add(12 * time.Hour))
+	require.Nil(t, spendableCoins)
+}
+
+func TestTrackDelegationGradVestingAcc(t *testing.T) {
+	genesis := timeGenesis
+
+	_, _, addr := keyPubAddr()
+	origCoins := sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 10000)}
+	bacc := auth.NewBaseAccountWithAddress(addr)
+
+	bacc.SetCoins(origCoins)
+	gva := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	gva.TrackDelegation(genesis, origCoins)
+	require.Equal(t, origCoins, gva.DelegatedVesting)
+	require.Nil(t, gva.DelegatedFree)
+	require.Nil(t, gva.GetCoins())
+
+	// require the ability to delegate all vested coins
+	bacc.SetCoins(origCoins)
+	gva = NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	gva.TrackDelegation(timeGenesis.AddDate(1, 0, 0), origCoins)
+	require.Nil(t, gva.DelegatedVesting)
+	require.Equal(t, origCoins, gva.DelegatedFree)
+	require.Nil(t, gva.GetCoins())
+
+	// require the ability to delegate all coins half way through the vesting
+	// schedule
+	bacc.SetCoins(origCoins)
+	gva = NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	gva.TrackDelegation(genesis.AddDate(0, 3, 0), sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 3000)})
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 3000)}, gva.DelegatedVesting)
+	require.Nil(t, gva.DelegatedFree)
+
+	gva.TrackDelegation(genesis.AddDate(0, 3, 0), sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 7000)})
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 7000)}, gva.DelegatedVesting)
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 3000)}, gva.DelegatedFree)
+	require.Nil(t, gva.GetCoins())
+
+	// require no modifications when delegation amount is zero or not enough funds
+	bacc.SetCoins(origCoins)
+	gva = NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+
+	require.Panics(t, func() {
+		gva.TrackDelegation(genesis.AddDate(1, 0, 0), sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 1000000)})
+	})
+	require.Nil(t, gva.DelegatedVesting)
+	require.Nil(t, gva.DelegatedFree)
+	require.Equal(t, origCoins, gva.GetCoins())
+}
+
+func TestTrackUndelegationGradVestingAcc(t *testing.T) {
+	genesis := timeGenesis
+
+	_, _, addr := keyPubAddr()
+	origCoins := sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 10000), sdk.NewInt64Coin(assets.MicroSDRDenom, 10000)}
+	bacc := auth.NewBaseAccountWithAddress(addr)
+	bacc.SetCoins(origCoins)
+
+	// require the ability to undelegate all vesting coins
+	gva := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	gva.TrackDelegation(genesis, origCoins)
+	gva.TrackUndelegation(origCoins)
+	require.Nil(t, gva.DelegatedFree)
+	require.Nil(t, gva.DelegatedVesting)
+	require.Equal(t, origCoins, gva.GetCoins())
+
+	// require the ability to undelegate all vested coins
+	bacc.SetCoins(origCoins)
+	gva = NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	gva.TrackDelegation(genesis.AddDate(1, 0, 0), origCoins)
+	gva.TrackUndelegation(origCoins)
+	require.Nil(t, gva.DelegatedFree)
+	require.Nil(t, gva.DelegatedVesting)
+	require.Equal(t, origCoins, gva.GetCoins())
+
+	// require no modifications when the undelegation amount is zero
+	bacc.SetCoins(origCoins)
+	gva = NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	require.Panics(t, func() {
+		gva.TrackUndelegation(sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 0)})
+	})
+	require.Nil(t, gva.DelegatedFree)
+	require.Nil(t, gva.DelegatedVesting)
+	require.Equal(t, origCoins, gva.GetCoins())
+
+	// vest 50% and delegate to two validators
+	gva = NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	gva.TrackDelegation(genesis.AddDate(0, 3, 0), sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 5000)})
+	gva.TrackDelegation(genesis.AddDate(0, 3, 0), sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 5000)})
+
+	// undelegate from one validator that got slashed 50%
+	gva.TrackUndelegation(sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 2500)})
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 500)}, gva.DelegatedFree)
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 7000)}, gva.DelegatedVesting)
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 2500), sdk.NewInt64Coin(assets.MicroSDRDenom, 10000)}, gva.GetCoins())
+
+	// undelegate from the other validator that did not get slashed
+	gva.TrackUndelegation(sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 5000)})
+	require.Nil(t, gva.DelegatedFree)
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 2500)}, gva.DelegatedVesting)
+	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 7500), sdk.NewInt64Coin(assets.MicroSDRDenom, 10000)}, gva.GetCoins())
+}
+
+func TestStringGradVestingAcc(t *testing.T) {
+
+	_, _, addr := keyPubAddr()
+	origCoins := sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 10000), sdk.NewInt64Coin(assets.MicroSDRDenom, 10000)}
+	bacc := auth.NewBaseAccountWithAddress(addr)
+	bacc.SetCoins(origCoins)
+
+	// require the ability to undelegate all vesting coins
+	gva := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+
+	require.NotNil(t, gva.String())
+	require.NotNil(t, gva.GetSchedules()[assets.MicroLunaDenom].String())
+}
+
+func TestIsValidGradVestingAcc(t *testing.T) {
+
+	_, _, addr := keyPubAddr()
+	origCoins := sdk.Coins{sdk.NewInt64Coin(assets.MicroLunaDenom, 10000), sdk.NewInt64Coin(assets.MicroSDRDenom, 10000)}
+	bacc := auth.NewBaseAccountWithAddress(addr)
+	bacc.SetCoins(origCoins)
+
+	// require the ability to undelegate all vesting coins
+	angelAccount := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: angelSchedule,
+	})
+	require.True(t, angelAccount.GetSchedules()[assets.MicroLunaDenom].IsValid())
+
+	seedAccount := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: seedSchedule,
+	})
+	require.True(t, seedAccount.GetSchedules()[assets.MicroLunaDenom].IsValid())
+
+	privateAccount := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: privateSchedule,
+	})
+	require.True(t, privateAccount.GetSchedules()[assets.MicroLunaDenom].IsValid())
+
+	employeeAccount := NewGradedVestingAccount(&bacc, map[string]VestingSchedule{
+		assets.MicroLunaDenom: employeeSchedule,
+	})
+	require.True(t, employeeAccount.GetSchedules()[assets.MicroLunaDenom].IsValid())
+}

--- a/x/market/client/cli/tx.go
+++ b/x/market/client/cli/tx.go
@@ -81,7 +81,7 @@ $ terracli market swap --offer-coin="1000krw" --ask-denom="usd"
 		},
 	}
 
-	cmd.Flags().String(flagOfferCoin, "", "The asset to swap from e.g. 1000mkrw")
+	cmd.Flags().String(flagOfferCoin, "", "The asset to swap from e.g. 1000ukrw")
 	cmd.Flags().String(flagAskDenom, "", "Denom of the asset to swap to")
 
 	return cmd

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -29,7 +29,7 @@ func GetCmdQueryPrice(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		Long: strings.TrimSpace(`
 Query the current price of a denom asset. You can find the current list of active denoms by running: terracli query oracle active
 
-$ terracli query oracle price --denom mkrw
+$ terracli query oracle price --denom ukrw
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -89,9 +89,9 @@ func GetCmdQueryVotes(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		Long: strings.TrimSpace(`
 Query outstanding oracle votes, filtered by denom and voter address.
 
-$ terracli query oracle votes --denom="musd" --voter="terrad8duyufdshs..."
+$ terracli query oracle votes --denom="uusd" --voter="terrad8duyufdshs..."
 
-returns oracle votes submitted by terrad8duyufdshs... for denom musd 
+returns oracle votes submitted by terrad8duyufdshs... for denom uusd 
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -29,9 +29,9 @@ func GetCmdPriceVote(cdc *codec.Codec) *cobra.Command {
 		Long: strings.TrimSpace(`
 Submit an oracle vote for the price of Luna denominated in the input denom.
 
-$ terracli oracle vote --denom "mkrw" --price "8890" --from mykey
+$ terracli oracle vote --denom "ukrw" --price "8890" --from mykey
 
-where "mkrw" is the denominating currency, and "8890" is the price of micro Luna in micro KRW from the voter's point of view. 
+where "ukrw" is the denominating currency, and "8890" is the price of micro Luna in micro KRW from the voter's point of view. 
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/x/treasury/client/cli/query.go
+++ b/x/treasury/client/cli/query.go
@@ -74,7 +74,7 @@ func GetCmdQueryTaxCap(cdc *codec.Codec) *cobra.Command {
 Query the current stability tax cap of the denom asset. 
 The stability tax levied on a tx is at most tax cap, regardless of the size of the transaction. 
 
-$ terracli query treasury taxcap --denom="mkrw"
+$ terracli query treasury taxcap --denom="ukrw"
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -112,7 +112,7 @@ func GetCmdQueryIssuance(cdc *codec.Codec) *cobra.Command {
 		Long: strings.TrimSpace(`
 Query the current issuance of a denom asset. 
 
-$ terracli query treasury issuance --denom="mkrw"
+$ terracli query treasury issuance --denom="ukrw"
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)


### PR DESCRIPTION
## Summary 

Terra genesis accounts have a unique vesting schedule that doesn't play nicely with continuousVestingAccount + DelayedVestingAccount implementation of the cosmos sdk. Doing our own! GradedVestingAccount allows the user to specify a "VestingSchedule", which maps the percentage of OriginalVesting tokens to become liquid to unix blocktimes. 

Must accomodate: 

- pre-seed investors (10%, 10%, 10%, 70%) 
- seed investors (10%, 10%, 10%, 70%) 
- private investors (10%, 10%, 10%, 10%, 10%) for Luna,  1/12 per year for TerraSDR
- employee vesting (3-4 years) 

## Changes

- Implemented a GradedVestingAccount that follows the above specs
- Changed genesis.json to play nicely with GradedVestingAccount

## Houskeeping

- [x] passes all existing tests
- [x] wrote new unit tests