### PR TITLE
Update genesis URL

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,18 +4,11 @@ This guide will explain how to install the `terrad` and `terracli` entrypoints o
 
 ### Install Go
 
-Install `go` by following the [official docs](https://golang.org/doc/install).
+Install `go` by following the [official docs](https://golang.org/doc/install). 
 
 ::: tip
 **Go 1.12+ +** is required for Terra Core.
 :::
-
-Linux example:
-```bash
-sudo snap install go --classic
-sudo apt install golang-statik
-curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
-```
 
 ### Install the binaries
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,11 +4,18 @@ This guide will explain how to install the `terrad` and `terracli` entrypoints o
 
 ### Install Go
 
-Install `go` by following the [official docs](https://golang.org/doc/install). 
+Install `go` by following the [official docs](https://golang.org/doc/install).
 
 ::: tip
 **Go 1.12+ +** is required for Terra Core.
 :::
+
+Linux example:
+```bash
+sudo snap install go --classic
+sudo apt install golang-statik
+curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
+```
 
 ### Install the binaries
 

--- a/docs/guide/join-network.md
+++ b/docs/guide/join-network.md
@@ -98,7 +98,7 @@ Fetch the testnet's `genesis.json` file into `terrad`'s config directory.
 
 ```bash
 mkdir -p $HOME/.terrad/config
-curl https://raw.githubusercontent.com/terra-project/networks/master/latest/genesis.json > $HOME/.terrad/config/genesis.json
+curl https://raw.githubusercontent.com/terra-project/launch/master/genesis.json > $HOME/.terrad/config/genesis.json
 ```
 
 Note we use the `latest` directory in the [networks repo](https://github.com/terra-project/networks)


### PR DESCRIPTION
1. Dependencies (`golang-statik` and `golangci-lint`) were missing on installation doc
2. `genesis.json` Github URL was outdated