### PR TITLE
Implement voting right delegation for oracle

### DIFF
--- a/x/bench/oracle_bench_test.go
+++ b/x/bench/oracle_bench_test.go
@@ -34,7 +34,7 @@ func BenchmarkOracleFeedVotePerBlock(b *testing.B) {
 
 		for j := 0; j < numOfValidators; j++ {
 			for d := 0; d < len(denoms); d++ {
-				voteMsg := oracle.NewMsgPriceFeed(denoms[d], sdk.NewDec(1), addrs[j])
+				voteMsg := oracle.NewMsgPriceFeed(denoms[d], sdk.NewDec(1), addrs[j], sdk.ValAddress(addrs[j]))
 
 				res := h(ctx, voteMsg)
 				if !res.IsOK() {

--- a/x/oracle/ballot_test.go
+++ b/x/oracle/ballot_test.go
@@ -56,7 +56,7 @@ func TestPBPower(t *testing.T) {
 	ballotPower := sdk.ZeroInt()
 
 	for i := 0; i < len(mockValset.Validators); i++ {
-		vote := NewPriceVote(sdk.ZeroDec(), assets.MicroSDRDenom, valAccAddrs[i])
+		vote := NewPriceVote(sdk.ZeroDec(), assets.MicroSDRDenom, sdk.ValAddress(valAccAddrs[i]))
 		pb = append(pb, vote)
 
 		valPower, err := vote.getPower(input.ctx, mockValset)
@@ -68,7 +68,7 @@ func TestPBPower(t *testing.T) {
 	require.Equal(t, ballotPower, pb.power(input.ctx, mockValset))
 
 	// Mix in a fake validator, the total power should not have changed.
-	fakeVote := NewPriceVote(sdk.OneDec(), assets.MicroSDRDenom, addrs[0])
+	fakeVote := NewPriceVote(sdk.OneDec(), assets.MicroSDRDenom, sdk.ValAddress(addrs[0]))
 	pb = append(pb, fakeVote)
 	require.Equal(t, ballotPower, pb.power(input.ctx, mockValset))
 }
@@ -125,7 +125,7 @@ func TestPBWeightedMedian(t *testing.T) {
 			if tc.isValidator[i] {
 				mockValset.Validators = append(mockValset.Validators, mockVal)
 			}
-			vote := NewPriceVote(sdk.NewDecWithPrec(int64(input*base), int64(oracleDecPrecision)), assets.MicroSDRDenom, valAccAddr)
+			vote := NewPriceVote(sdk.NewDecWithPrec(int64(input*base), int64(oracleDecPrecision)), assets.MicroSDRDenom, sdk.ValAddress(valAccAddr))
 			pb = append(pb, vote)
 		}
 

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -2,10 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/terra-project/core/types/assets"
 	"github.com/terra-project/core/x/oracle"
-	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -198,9 +199,9 @@ $ terracli query oracle feeder-delegation --validator terravaloper1ifji3ifj
 				return err
 			}
 
-			var actives DenomList
-			cdc.MustUnmarshalJSON(res, &actives)
-			return cliCtx.PrintOutput(actives)
+			var delegatee sdk.AccAddress
+			cdc.MustUnmarshalJSON(res, &delegatee)
+			return cliCtx.PrintOutput(delegatee)
 		},
 	}
 

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -163,3 +163,32 @@ func GetCmdQueryParams(queryRoute string, cdc *codec.Codec) *cobra.Command {
 
 	return cmd
 }
+
+// GetCmdQueryFeederDelegation implements the query feeder delegation command
+func GetCmdQueryFeederDelegation(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   oracle.QueryActive,
+		Short: "Query the account the validator's voting right is delegated to",
+		Long: strings.TrimSpace(`
+Query the account the validator's voting right is delegated to.
+
+$ terracli query oracle feeder-delegation --validator terravaloper1ifji3ifj
+`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, oracle.QueryActive), nil)
+			if err != nil {
+				return err
+			}
+
+			var actives DenomList
+			cdc.MustUnmarshalJSON(res, &actives)
+			return cliCtx.PrintOutput(actives)
+		},
+	}
+
+	cmd.Flags().String(flagValidator, "", "validator to get the delegation for")
+
+	return cmd
+}

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -2,8 +2,9 @@ package cli
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/terra-project/core/x/oracle"
 
@@ -21,7 +22,7 @@ const (
 	flagPrice     = "price"
 	flagVoter     = "voter"
 	flagValidator = "validator"
-	flagDelegate  = "delegate"
+	flagDelegatee = "delegated"
 )
 
 // GetCmdPriceVote will create a send tx and sign it with the given key.
@@ -110,7 +111,7 @@ func GetCmdDelegateFeederPermission(cdc *codec.Codec) *cobra.Command {
 Delegate the permission to vote for the oracle to an address.
 That way you can keep your validator operator key offline and use a separate replaceable key online.
 
-$ terracli oracle set-feeder --delegate terra1...... --from mykey
+$ terracli oracle set-feeder --delegatee terra1...... --from mykey
 
 where "terra1abceuihfu93fud" is the address you want to delegate your voting rights to.
 `),
@@ -131,16 +132,16 @@ where "terra1abceuihfu93fud" is the address you want to delegate your voting rig
 			// The address the right is being delegated from
 			validator := sdk.ValAddress(voter)
 
-			delegateStr := viper.GetString(flagDelegate)
-			if len(delegateStr) == 0 {
+			delegateeStr := viper.GetString(flagDelegatee)
+			if len(delegateeStr) == 0 {
 				return fmt.Errorf("--delegate flag is required")
 			}
-			delegate, err := sdk.AccAddressFromBech32(delegateStr)
+			delegatee, err := sdk.AccAddressFromBech32(delegateeStr)
 			if err != nil {
 				return errors.Wrap(err, "delegate is not a valid account address")
 			}
 
-			msg := oracle.NewMsgDelegateFeederPermission(validator, delegate)
+			msg := oracle.NewMsgDelegateFeederPermission(validator, delegatee)
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
@@ -150,7 +151,9 @@ where "terra1abceuihfu93fud" is the address you want to delegate your voting rig
 		},
 	}
 
-	cmd.Flags().String(flagDelegate, "", "account the voting right will be delegated to")
+	cmd.Flags().String(flagDelegatee, "", "account the voting right will be delegated to")
+
+	cmd.MarkFlagRequired(flagDelegatee)
 
 	return cmd
 }

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/terra-project/core/x/oracle"
@@ -16,9 +17,11 @@ import (
 )
 
 const (
-	flagDenom = "denom"
-	flagPrice = "price"
-	flagVoter = "voter"
+	flagDenom     = "denom"
+	flagPrice     = "price"
+	flagVoter     = "voter"
+	flagValidator = "validator"
+	flagDelegate  = "delegate"
 )
 
 // GetCmdPriceVote will create a send tx and sign it with the given key.
@@ -59,13 +62,26 @@ where "ukrw" is the denominating currency, and "8890" is the price of micro Luna
 				return fmt.Errorf("--price flag is required")
 			}
 
+			// By default the voter is voting on behalf of itself
+			validator := sdk.ValAddress(voter)
+
+			// Override validator if flag is set
+			valStr := viper.GetString(flagValidator)
+			if len(valStr) != 0 {
+				parsedVal, err := sdk.ValAddressFromBech32(valStr)
+				if err != nil {
+					return errors.Wrap(err, "validator address is invalid")
+				}
+				validator = parsedVal
+			}
+
 			// Parse the price to Dec
 			price, err := sdk.NewDecFromStr(priceStr)
 			if err != nil {
 				return fmt.Errorf("given price {%s} is not a valid format; price should be formatted as float", priceStr)
 			}
 
-			msg := oracle.NewMsgPriceFeed(denom, price, voter)
+			msg := oracle.NewMsgPriceFeed(denom, price, voter, validator)
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
@@ -77,6 +93,61 @@ where "ukrw" is the denominating currency, and "8890" is the price of micro Luna
 
 	cmd.Flags().String(flagDenom, "", "denominating currency")
 	cmd.Flags().String(flagPrice, "", "price of Luna in denom currency")
+	cmd.Flags().String(flagValidator, "", "validator on behalf of which to vote (for delegated feeders)")
+
+	return cmd
+}
+
+// GetCmdDelegateFeederPermission will create a feeder permission delegation tx and sign it with the given key.
+func GetCmdDelegateFeederPermission(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-feeder",
+		Short: "Delegate the permission to vote for the oracle to an address",
+		Long: strings.TrimSpace(`
+Delegate the permission to vote for the oracle to an address.
+That way you can keep your validator operator key offline and use a separate replaceable key online.
+
+$ terracli oracle set-feeder --delegate terra1abceuihfu93fud --from mykey
+
+where "terra1abceuihfu93fud" is the address you want to delegate your voting rights to.
+`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+			cliCtx := context.NewCLIContext().
+				WithCodec(cdc).
+				WithAccountDecoder(cdc)
+
+			if err := cliCtx.EnsureAccountExists(); err != nil {
+				return err
+			}
+
+			// Get from address
+			voter := cliCtx.GetFromAddress()
+
+			// The address the right is being delegated from
+			validator := sdk.ValAddress(voter)
+
+			delegateStr := viper.GetString(flagDelegate)
+			if len(delegateStr) == 0 {
+				return fmt.Errorf("--delegate flag is required")
+			}
+			delegate, err := sdk.AccAddressFromBech32(delegateStr)
+			if err != nil {
+				return errors.Wrap(err, "delegate is not a valid account address")
+			}
+
+			msg := oracle.NewMsgDelegateFeederPermission(validator, delegate)
+			err = msg.ValidateBasic()
+			if err != nil {
+				return err
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg}, false)
+		},
+	}
+
+	cmd.Flags().String(flagDelegate, "", "account the voting right will be delegated to")
 
 	return cmd
 }

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -34,7 +34,10 @@ Submit an oracle vote for the price of Luna denominated in the input denom.
 
 $ terracli oracle vote --denom "ukrw" --price "8890" --from mykey
 
-where "ukrw" is the denominating currency, and "8890" is the price of micro Luna in micro KRW from the voter's point of view. 
+where "ukrw" is the denominating currency, and "8890" is the price of micro Luna in micro KRW from the voter's point of view.
+
+If voting from a voting delegate, set "validator" to the address of the validator to vote on behalf of:
+$ terracli oracle vote --denom "ukrw" --price "8890" --from mykey --validator terravaloper1.......
 `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -107,7 +110,7 @@ func GetCmdDelegateFeederPermission(cdc *codec.Codec) *cobra.Command {
 Delegate the permission to vote for the oracle to an address.
 That way you can keep your validator operator key offline and use a separate replaceable key online.
 
-$ terracli oracle set-feeder --delegate terra1abceuihfu93fud --from mykey
+$ terracli oracle set-feeder --delegate terra1...... --from mykey
 
 where "terra1abceuihfu93fud" is the address you want to delegate your voting rights to.
 `),

--- a/x/oracle/client/module_client.go
+++ b/x/oracle/client/module_client.go
@@ -29,6 +29,7 @@ func (mc ModuleClient) GetQueryCmd() *cobra.Command {
 		cli.GetCmdQueryVotes(mc.storeKey, mc.cdc),
 		cli.GetCmdQueryActive(mc.storeKey, mc.cdc),
 		cli.GetCmdQueryParams(mc.storeKey, mc.cdc),
+		cli.GetCmdQueryFeederDelegation(mc.storeKey, mc.cdc),
 	)...)
 
 	return oracleQueryCmd
@@ -44,6 +45,7 @@ func (mc ModuleClient) GetTxCmd() *cobra.Command {
 
 	oracleTxCmd.AddCommand(client.PostCommands(
 		cli.GetCmdPriceVote(mc.cdc),
+		cli.GetCmdDelegateFeederPermission(mc.cdc),
 	)...)
 
 	return oracleTxCmd

--- a/x/oracle/client/rest/query.go
+++ b/x/oracle/client/rest/query.go
@@ -2,9 +2,10 @@ package rest
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/terra-project/core/types/assets"
 	"github.com/terra-project/core/x/oracle"
-	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -19,6 +20,7 @@ func registerQueryRoute(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Cod
 	r.HandleFunc(fmt.Sprintf("/oracle/denoms/{%s}/price", RestDenom), queryPriceHandlerFunction(cdc, cliCtx)).Methods("GET")
 	r.HandleFunc("/oracle/denoms/actives", queryActivesHandlerFunction(cdc, cliCtx)).Methods("GET")
 	r.HandleFunc("/oracle/params", queryParamsHandlerFn(cdc, cliCtx)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/oracle/voters/{%s}/delegation", RestVoter), queryFeederDelegationHandlerFn(cdc, cliCtx)).Methods("GET")
 }
 
 func queryVotesHandlerFunction(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
@@ -34,12 +36,12 @@ func queryVotesHandlerFunction(cdc *codec.Codec, cliCtx context.CLIContext) http
 
 		voter := vars[RestVoter]
 
-		var voterAddress sdk.AccAddress
+		var voterAddress sdk.ValAddress
 		params := oracle.NewQueryVoteParams(voterAddress, denom)
 
 		if len(voter) != 0 {
 
-			voterAddress, err := sdk.AccAddressFromBech32(voter)
+			voterAddress, err := sdk.ValAddressFromBech32(voter)
 			if err != nil {
 				return
 			}
@@ -103,6 +105,37 @@ func queryParamsHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.Hand
 			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
 			return
 		}
+
+		rest.PostProcessResponse(w, cdc, res, cliCtx.Indent)
+	}
+}
+
+func queryFeederDelegationHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		voter := vars[RestVoter]
+
+		validator, err := sdk.ValAddressFromBech32(voter)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		params := oracle.NewQueryFeederDelegationParams(validator)
+		bz, err := cdc.MarshalJSON(params)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", oracle.QuerierRoute, oracle.QueryFeederDelegation), bz)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
+			return
+		}
+
+		var delegatee sdk.AccAddress
+		cdc.MustUnmarshalJSON(res, &delegatee)
 
 		rest.PostProcessResponse(w, cdc, res, cliCtx.Indent)
 	}

--- a/x/oracle/codec.go
+++ b/x/oracle/codec.go
@@ -9,6 +9,7 @@ var msgCdc = codec.New()
 // RegisterCodec registers concrete types on codec codec
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgPriceFeed{}, "oracle/MsgPriceFeed", nil)
+	cdc.RegisterConcrete(MsgDelegateFeederPermission{}, "oracle/MsgDelegateFeederPermission", nil)
 
 	cdc.RegisterConcrete(&PriceBallot{}, "oracle/PriceBallot", nil)
 	cdc.RegisterConcrete(&PriceVote{}, "oracle/PriceVote", nil)

--- a/x/oracle/end_blocker.go
+++ b/x/oracle/end_blocker.go
@@ -28,7 +28,7 @@ func tally(ctx sdk.Context, k Keeper, pb PriceBallot) (weightedMedian sdk.Dec, b
 				bondSize := validator.GetBondedTokens()
 
 				ballotWinners = append(ballotWinners, types.Claim{
-					Recipient: vote.Voter,
+					Recipient: sdk.AccAddress(vote.Voter),
 					Weight:    bondSize,
 					Class:     types.OracleClaimClass,
 				})

--- a/x/oracle/end_blocker.go
+++ b/x/oracle/end_blocker.go
@@ -23,8 +23,7 @@ func tally(ctx sdk.Context, k Keeper, pb PriceBallot) (weightedMedian sdk.Dec, b
 
 	for _, vote := range pb {
 		if vote.Price.GTE(weightedMedian.Sub(rewardSpread)) && vote.Price.LTE(weightedMedian.Add(rewardSpread)) {
-			valAddr := sdk.ValAddress(vote.Voter)
-			if validator := k.valset.Validator(ctx, valAddr); validator != nil {
+			if validator := k.valset.Validator(ctx, vote.Voter); validator != nil {
 				bondSize := validator.GetBondedTokens()
 
 				ballotWinners = append(ballotWinners, types.Claim{

--- a/x/oracle/errors.go
+++ b/x/oracle/errors.go
@@ -10,10 +10,11 @@ import (
 const (
 	DefaultCodespace sdk.CodespaceType = "oracle"
 
-	CodeUnknownDenom      sdk.CodeType = 1
-	CodeInvalidPrice      sdk.CodeType = 2
-	CodeVoterNotValidator sdk.CodeType = 3
-	CodeInvalidVote       sdk.CodeType = 4
+	CodeUnknownDenom       sdk.CodeType = 1
+	CodeInvalidPrice       sdk.CodeType = 2
+	CodeVoterNotValidator  sdk.CodeType = 3
+	CodeInvalidVote        sdk.CodeType = 4
+	CodeNoVotingPermission sdk.CodeType = 5
 )
 
 // ----------------------------------------
@@ -30,11 +31,16 @@ func ErrInvalidPrice(codespace sdk.CodespaceType, price sdk.Dec) sdk.Error {
 }
 
 // ErrVoterNotValidator called when the voter is not a validator
-func ErrVoterNotValidator(codespace sdk.CodespaceType, voter sdk.AccAddress) sdk.Error {
+func ErrVoterNotValidator(codespace sdk.CodespaceType, voter sdk.ValAddress) sdk.Error {
 	return sdk.NewError(codespace, CodeVoterNotValidator, fmt.Sprintf("Voter is not a validator: %s", voter.String()))
 }
 
 // ErrNoVote called when no vote exists
-func ErrNoVote(codespace sdk.CodespaceType, voter sdk.AccAddress, denom string) sdk.Error {
+func ErrNoVote(codespace sdk.CodespaceType, voter sdk.ValAddress, denom string) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidVote, fmt.Sprintf("No vote exists from %s with denom: %s", voter, denom))
+}
+
+// ErrNoVotingPermission called when the feeder has no permission to submit a vote for the given operator
+func ErrNoVotingPermission(codespace sdk.CodespaceType, feeder sdk.AccAddress, operator sdk.ValAddress) sdk.Error {
+	return sdk.NewError(codespace, CodeNoVotingPermission, fmt.Sprintf("Feeder %s not permitted to vote on behalf of: %s", feeder.String(), operator.String()))
 }

--- a/x/oracle/handler.go
+++ b/x/oracle/handler.go
@@ -34,7 +34,7 @@ func handleMsgPriceFeed(ctx sdk.Context, keeper Keeper, pfm MsgPriceFeed) sdk.Re
 	}
 
 	// Check that the given validator exists
-	val := valset.Validator(ctx, sdk.ValAddress(pfm.Validator.Bytes()))
+	val := valset.Validator(ctx, pfm.Validator)
 	if val == nil {
 		return staking.ErrNoValidatorFound(DefaultCodespace).Result()
 	}
@@ -59,7 +59,7 @@ func handleMsgDelegateFeederPermission(ctx sdk.Context, keeper Keeper, pfm MsgDe
 	signer := pfm.Operator
 
 	// Check the delegator is a validator
-	val := valset.Validator(ctx, sdk.ValAddress(signer.Bytes()))
+	val := valset.Validator(ctx, signer)
 	if val == nil {
 		return staking.ErrNoValidatorFound(DefaultCodespace).Result()
 	}

--- a/x/oracle/handler_test.go
+++ b/x/oracle/handler_test.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"github.com/cosmos/cosmos-sdk/types"
 	"testing"
 
 	"github.com/terra-project/core/types/assets"
@@ -19,13 +20,47 @@ func TestOracleFilters(t *testing.T) {
 	require.False(t, res.IsOK())
 
 	// Case 2: Normal MsgPriceFeed submission goes through
-	msg := NewMsgPriceFeed(assets.MicroSDRDenom, randomPrice, addrs[0])
+	msg := NewMsgPriceFeed(assets.MicroSDRDenom, randomPrice, addrs[0], types.ValAddress(addrs[0]))
 	res = h(input.ctx, msg)
 	require.True(t, res.IsOK())
 
 	// Case 3: a non-validator sending an oracle message fails
 	_, randoAddrs := cosmock.GeneratePrivKeyAddressPairs(1)
-	msg = NewMsgPriceFeed(assets.MicroSDRDenom, randomPrice, randoAddrs[0])
+	msg = NewMsgPriceFeed(assets.MicroSDRDenom, randomPrice, randoAddrs[0], types.ValAddress(randoAddrs[0]))
 	res = h(input.ctx, msg)
 	require.False(t, res.IsOK())
+}
+
+func TestFeederDelegation(t *testing.T) {
+	input, h := setup(t)
+
+	// Case 1: empty message
+	bankMsg := MsgDelegateFeederPermission{}
+	res := h(input.ctx, bankMsg)
+	require.False(t, res.IsOK())
+
+	// Case 2: Normal Vote - without delegation
+	priceMsg := NewMsgPriceFeed(assets.MicroSDRDenom, randomPrice, addrs[0], types.ValAddress(addrs[0]))
+	res = h(input.ctx, priceMsg)
+	require.True(t, res.IsOK())
+
+	// Case 2.1: Normal Vote - with delegation fails
+	priceMsg = NewMsgPriceFeed(assets.MicroSDRDenom, randomPrice, addrs[1], types.ValAddress(addrs[0]))
+	res = h(input.ctx, priceMsg)
+	require.False(t, res.IsOK())
+
+	// Case 3: Normal MsgDelegateFeederPermission succeeds
+	msg := NewMsgDelegateFeederPermission(types.ValAddress(addrs[0]), addrs[1])
+	res = h(input.ctx, msg)
+	require.True(t, res.IsOK())
+
+	// Case 4: Normal Vote - without delegation fails
+	priceMsg = NewMsgPriceFeed(assets.MicroSDRDenom, randomPrice, addrs[2], types.ValAddress(addrs[0]))
+	res = h(input.ctx, priceMsg)
+	require.False(t, res.IsOK())
+
+	// Case 5: Normal Vote - with delegation succeeds
+	priceMsg = NewMsgPriceFeed(assets.MicroSDRDenom, randomPrice, addrs[1], types.ValAddress(addrs[0]))
+	res = h(input.ctx, priceMsg)
+	require.True(t, res.IsOK())
 }

--- a/x/oracle/keeper_keys.go
+++ b/x/oracle/keeper_keys.go
@@ -8,13 +8,14 @@ import (
 )
 
 var (
-	prefixVote          = []byte("vote")
-	prefixPrice         = []byte("price")
-	prefixDropCounter   = []byte("drop")
-	paramStoreKeyParams = []byte("params")
+	prefixVote             = []byte("vote")
+	prefixPrice            = []byte("price")
+	prefixDropCounter      = []byte("drop")
+	paramStoreKeyParams    = []byte("params")
+	prefixFeederDelegation = []byte("feederdelegation")
 )
 
-func keyVote(denom string, voter sdk.AccAddress) []byte {
+func keyVote(denom string, voter sdk.ValAddress) []byte {
 	return []byte(fmt.Sprintf("%s:%s:%s", prefixVote, denom, voter))
 }
 
@@ -30,4 +31,8 @@ func paramKeyTable() params.KeyTable {
 	return params.NewKeyTable(
 		paramStoreKeyParams, Params{},
 	)
+}
+
+func keyFeederDelegation(delegate sdk.ValAddress) []byte {
+	return []byte(fmt.Sprintf("%s:%s", prefixFeederDelegation, delegate))
 }

--- a/x/oracle/keeper_test.go
+++ b/x/oracle/keeper_test.go
@@ -43,11 +43,11 @@ func TestKeeperVote(t *testing.T) {
 	input := createTestInput(t)
 
 	// Test addvote
-	vote := NewPriceVote(sdk.OneDec(), assets.MicroSDRDenom, addrs[0])
+	vote := NewPriceVote(sdk.OneDec(), assets.MicroSDRDenom, sdk.ValAddress(addrs[0]))
 	input.oracleKeeper.addVote(input.ctx, vote)
 
 	// Test getVote
-	voteQuery, err := input.oracleKeeper.getVote(input.ctx, assets.MicroSDRDenom, addrs[0])
+	voteQuery, err := input.oracleKeeper.getVote(input.ctx, assets.MicroSDRDenom, sdk.ValAddress(addrs[0]))
 	require.Nil(t, err)
 	require.Equal(t, vote, voteQuery)
 
@@ -65,7 +65,7 @@ func TestKeeperVote(t *testing.T) {
 
 	// Test deletevote
 	input.oracleKeeper.deleteVote(input.ctx, vote)
-	_, err = input.oracleKeeper.getVote(input.ctx, assets.MicroSDRDenom, addrs[0])
+	_, err = input.oracleKeeper.getVote(input.ctx, assets.MicroSDRDenom, sdk.ValAddress(addrs[0]))
 	require.NotNil(t, err)
 }
 
@@ -104,4 +104,23 @@ func TestKeeperParams(t *testing.T) {
 	storedParams := input.oracleKeeper.GetParams(input.ctx)
 	require.NotNil(t, storedParams)
 	require.Equal(t, newParams, storedParams)
+}
+
+func TestKeeperFeederDelegation(t *testing.T) {
+	input := createTestInput(t)
+
+	// Test default getters and setters
+	delegate := input.oracleKeeper.GetFeedDelegate(input.ctx, sdk.ValAddress(addrs[0]))
+	require.Equal(t, delegate, addrs[0])
+
+	input.oracleKeeper.SetFeedDelegate(input.ctx, sdk.ValAddress(addrs[0]), addrs[1])
+	delegate = input.oracleKeeper.GetFeedDelegate(input.ctx, sdk.ValAddress(addrs[0]))
+	require.Equal(t, delegate, addrs[1])
+
+	// Test iterator
+	input.oracleKeeper.SetFeedDelegate(input.ctx, sdk.ValAddress(addrs[1]), addrs[1])
+	delegations := input.oracleKeeper.GetOperatorsForDelegate(input.ctx, addrs[1])
+	require.Equal(t, len(delegations), 2)
+	require.Contains(t, delegations, sdk.ValAddress(addrs[0]))
+	require.Contains(t, delegations, sdk.ValAddress(addrs[1]))
 }

--- a/x/oracle/msg.go
+++ b/x/oracle/msg.go
@@ -13,17 +13,19 @@ import (
 // For example, if the validator believes that the effective price of Luna in USD is 10.39, that's
 // what the price field would be, and if 1213.34 for KRW, same.
 type MsgPriceFeed struct {
-	Denom  string         `json:"denom"`
-	Price  sdk.Dec        `json:"price"` // the effective price of Luna in {Denom}
-	Feeder sdk.AccAddress `json:"feeder"`
+	Denom     string         `json:"denom"`
+	Price     sdk.Dec        `json:"price"` // the effective price of Luna in {Denom}
+	Feeder    sdk.AccAddress `json:"feeder"`
+	Validator sdk.ValAddress `json:"validator"`
 }
 
 // NewMsgPriceFeed creates a MsgPriceFeed instance
-func NewMsgPriceFeed(denom string, price sdk.Dec, feederAddress sdk.AccAddress) MsgPriceFeed {
+func NewMsgPriceFeed(denom string, price sdk.Dec, feederAddress sdk.AccAddress, valAddress sdk.ValAddress) MsgPriceFeed {
 	return MsgPriceFeed{
-		Denom:  denom,
-		Price:  price,
-		Feeder: feederAddress,
+		Denom:     denom,
+		Price:     price,
+		Feeder:    feederAddress,
+		Validator: valAddress,
 	}
 }
 
@@ -53,6 +55,10 @@ func (msg MsgPriceFeed) ValidateBasic() sdk.Error {
 		return sdk.ErrInvalidAddress("Invalid address: " + msg.Feeder.String())
 	}
 
+	if msg.Validator.Empty() {
+		return sdk.ErrInvalidAddress("Invalid address: " + msg.Feeder.String())
+	}
+
 	if msg.Price.LTE(sdk.ZeroDec()) {
 		return ErrInvalidPrice(DefaultCodespace, msg.Price)
 	}
@@ -64,7 +70,59 @@ func (msg MsgPriceFeed) ValidateBasic() sdk.Error {
 func (msg MsgPriceFeed) String() string {
 	return fmt.Sprintf(`MsgPriceFeed
 	feeder:    %s, 
+	validator:    %s, 
 	denom:     %s, 
 	price:     %s`,
-		msg.Feeder, msg.Denom, msg.Price)
+		msg.Feeder, msg.Validator, msg.Denom, msg.Price)
+}
+
+// MsgDelegateFeederPermission - struct for delegating oracle voting rights to another address.
+type MsgDelegateFeederPermission struct {
+	Operator     sdk.ValAddress `json:"operator"`
+	FeedDelegate sdk.AccAddress `json:"feed_delegate"`
+}
+
+// NewMsgDelegateFeederPermission creates a MsgDelegateFeederPermission instance
+func NewMsgDelegateFeederPermission(operatorAddress sdk.ValAddress, feederAddress sdk.AccAddress) MsgDelegateFeederPermission {
+	return MsgDelegateFeederPermission{
+		Operator:     operatorAddress,
+		FeedDelegate: feederAddress,
+	}
+}
+
+// Route Implements Msg
+func (msg MsgDelegateFeederPermission) Route() string { return RouterKey }
+
+// Type implements sdk.Msg
+func (msg MsgDelegateFeederPermission) Type() string { return "delegatefeeder" }
+
+// GetSignBytes implements sdk.Msg
+func (msg MsgDelegateFeederPermission) GetSignBytes() []byte {
+	return sdk.MustSortJSON(msgCdc.MustMarshalJSON(msg))
+}
+
+// GetSigners implements sdk.Msg
+func (msg MsgDelegateFeederPermission) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{sdk.AccAddress(msg.Operator)}
+}
+
+// ValidateBasic Implements sdk.Msg
+func (msg MsgDelegateFeederPermission) ValidateBasic() sdk.Error {
+	if msg.Operator.Empty() {
+		return sdk.ErrInvalidAddress("Invalid address: " + msg.Operator.String())
+	}
+
+	if msg.FeedDelegate.Empty() {
+		return sdk.ErrInvalidAddress("Invalid address: " + msg.Operator.String())
+	}
+
+	return nil
+}
+
+// String Implements Msg
+func (msg MsgDelegateFeederPermission) String() string {
+	return fmt.Sprintf(`MsgDelegateFeederPermission
+	operator:    %s, 
+	feed_delegate:     %s`,
+		msg.Operator, msg.FeedDelegate)
 }

--- a/x/oracle/msg_test.go
+++ b/x/oracle/msg_test.go
@@ -24,7 +24,7 @@ func TestMsgPriceFeed(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		msg := NewMsgPriceFeed(tc.denom, tc.price, tc.voter)
+		msg := NewMsgPriceFeed(tc.denom, tc.price, tc.voter, sdk.ValAddress(tc.voter))
 		if tc.expectPass {
 			require.Nil(t, msg.ValidateBasic(), "test: %v", i)
 		} else {

--- a/x/oracle/querier.go
+++ b/x/oracle/querier.go
@@ -9,10 +9,11 @@ import (
 
 // query endpoints supported by the oracle Querier
 const (
-	QueryPrice  = "price"
-	QueryVotes  = "votes"
-	QueryActive = "active"
-	QueryParams = "params"
+	QueryPrice            = "price"
+	QueryVotes            = "votes"
+	QueryActive           = "active"
+	QueryParams           = "params"
+	QueryFeederDelegation = "feeder-delegation"
 )
 
 // NewQuerier is the module level router for state queries
@@ -27,6 +28,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return queryVotes(ctx, req, keeper)
 		case QueryParams:
 			return queryParams(ctx, req, keeper)
+		case QueryFeederDelegation:
+			return queryFeederDelegation(ctx, req, keeper)
 		default:
 			return nil, sdk.ErrUnknownRequest("unknown oracle query endpoint")
 		}
@@ -62,12 +65,12 @@ func queryActive(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte,
 
 // QueryVoteParams for query 'custom/oracle/votes'
 type QueryVoteParams struct {
-	Voter sdk.AccAddress
+	Voter sdk.ValAddress
 	Denom string
 }
 
 // NewQueryVoteParams creates a new instance of QueryVoteParams
-func NewQueryVoteParams(voter sdk.AccAddress, denom string) QueryVoteParams {
+func NewQueryVoteParams(voter sdk.ValAddress, denom string) QueryVoteParams {
 	return QueryVoteParams{
 		Voter: voter,
 		Denom: denom,
@@ -94,7 +97,7 @@ func queryVotes(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, 
 	if len(params.Denom) != 0 && !params.Voter.Empty() {
 		prefix = keyVote(params.Denom, params.Voter)
 	} else if len(params.Denom) != 0 {
-		prefix = keyVote(params.Denom, sdk.AccAddress{})
+		prefix = keyVote(params.Denom, sdk.ValAddress{})
 	} else if !params.Voter.Empty() {
 		handler = func(vote PriceVote) (stop bool) {
 
@@ -117,6 +120,32 @@ func queryVotes(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, 
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, keeper.GetParams(ctx))
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
+	}
+	return bz, nil
+}
+
+// QueryFeederDelegationParams for query 'custom/oracle/feeder-delegation'
+type QueryFeederDelegationParams struct {
+	Validator sdk.ValAddress
+}
+
+// NewQueryFeederDelegationParams creates a new instance of QueryFeederDelegationParams
+func NewQueryFeederDelegationParams(validator sdk.ValAddress) QueryFeederDelegationParams {
+	return QueryFeederDelegationParams{
+		Validator: validator,
+	}
+}
+
+func queryFeederDelegation(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	var params QueryFeederDelegationParams
+	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
+		return nil, sdk.ErrUnknownRequest(sdk.AppendMsgToErr("incorrectly formatted request data", err.Error()))
+	}
+
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, keeper.GetFeedDelegate(ctx, params.Validator))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/x/oracle/tags/tags.go
+++ b/x/oracle/tags/tags.go
@@ -16,4 +16,7 @@ var (
 	Voter  = "voter"
 	Power  = "power"
 	Price  = "price"
+
+	Operator     = "operator"
+	FeedDelegate = "feed_delegate"
 )

--- a/x/oracle/test_common.go
+++ b/x/oracle/test_common.go
@@ -38,8 +38,8 @@ var (
 		sdk.AccAddress(pubKeys[2].Address()),
 	}
 
-	uSDRAmt  = sdk.NewInt(1005 * assets.MicroUnit)
-	uLunaAmt = sdk.NewInt(10 * assets.MicroUnit)
+	mSDRAmt  = sdk.NewInt(1005 * assets.MicroUnit)
+	mLunaAmt = sdk.NewInt(10 * assets.MicroUnit)
 
 	oracleDecPrecision = 8
 )
@@ -105,14 +105,14 @@ func createTestInput(t *testing.T) testInput {
 	valset := mock.NewMockValSet()
 	for _, addr := range addrs {
 		_, _, err := bankKeeper.AddCoins(ctx, addr, sdk.Coins{
-			sdk.NewCoin(assets.MicroLunaDenom, uLunaAmt),
-			sdk.NewCoin(assets.MicroSDRDenom, uSDRAmt),
+			sdk.NewCoin(assets.MicroLunaDenom, mLunaAmt),
+			sdk.NewCoin(assets.MicroSDRDenom, mSDRAmt),
 		})
 
 		require.NoError(t, err)
 
 		// Add validators
-		validator := mock.NewMockValidator(sdk.ValAddress(addr.Bytes()), uLunaAmt)
+		validator := mock.NewMockValidator(sdk.ValAddress(addr.Bytes()), mLunaAmt)
 		valset.Validators = append(valset.Validators, validator)
 	}
 

--- a/x/oracle/test_common.go
+++ b/x/oracle/test_common.go
@@ -38,8 +38,8 @@ var (
 		sdk.AccAddress(pubKeys[2].Address()),
 	}
 
-	mSDRAmt  = sdk.NewInt(1005 * assets.MicroUnit)
-	mLunaAmt = sdk.NewInt(10 * assets.MicroUnit)
+	uSDRAmt  = sdk.NewInt(1005 * assets.MicroUnit)
+	uLunaAmt = sdk.NewInt(10 * assets.MicroUnit)
 
 	oracleDecPrecision = 8
 )
@@ -105,14 +105,14 @@ func createTestInput(t *testing.T) testInput {
 	valset := mock.NewMockValSet()
 	for _, addr := range addrs {
 		_, _, err := bankKeeper.AddCoins(ctx, addr, sdk.Coins{
-			sdk.NewCoin(assets.MicroLunaDenom, mLunaAmt),
-			sdk.NewCoin(assets.MicroSDRDenom, mSDRAmt),
+			sdk.NewCoin(assets.MicroLunaDenom, uLunaAmt),
+			sdk.NewCoin(assets.MicroSDRDenom, uSDRAmt),
 		})
 
 		require.NoError(t, err)
 
 		// Add validators
-		validator := mock.NewMockValidator(sdk.ValAddress(addr.Bytes()), mLunaAmt)
+		validator := mock.NewMockValidator(sdk.ValAddress(addr.Bytes()), uLunaAmt)
 		valset.Validators = append(valset.Validators, validator)
 	}
 

--- a/x/oracle/vote.go
+++ b/x/oracle/vote.go
@@ -10,11 +10,11 @@ import (
 type PriceVote struct {
 	Price sdk.Dec        `json:"price"` // Price of Luna in target fiat currency
 	Denom string         `json:"denom"` // Ticker name of target fiat currency
-	Voter sdk.AccAddress `json:"voter"` // account address of validator
+	Voter sdk.ValAddress `json:"voter"` // account address of validator
 }
 
 // NewPriceVote creates a PriceVote instance
-func NewPriceVote(price sdk.Dec, denom string, voter sdk.AccAddress) PriceVote {
+func NewPriceVote(price sdk.Dec, denom string, voter sdk.ValAddress) PriceVote {
 	return PriceVote{
 		Price: price,
 		Denom: denom,
@@ -23,8 +23,7 @@ func NewPriceVote(price sdk.Dec, denom string, voter sdk.AccAddress) PriceVote {
 }
 
 func (pv PriceVote) getPower(ctx sdk.Context, valset sdk.ValidatorSet) (sdk.Int, sdk.Error) {
-	valAddr := sdk.ValAddress(pv.Voter)
-	if validator := valset.Validator(ctx, valAddr); validator != nil {
+	if validator := valset.Validator(ctx, pv.Voter); validator != nil {
 		return validator.GetBondedTokens(), nil
 	}
 


### PR DESCRIPTION
I implemented delegation of oracle voting rights to other Account addresses.

By using the `MsgDelegateFeederPermission` a validator can assign the right to vote to another account at any time. The validator account will preserve its right to vote at any time.

A single account can have the right to vote on behalf of multiple validators.

A vote message must now contain the validator to vote on behalf of and the sender/feeder address.