### PR TITLE
Bugfix/periodic tax cap update

### DIFF
--- a/x/treasury/end_blocker.go
+++ b/x/treasury/end_blocker.go
@@ -28,6 +28,7 @@ func EndBlocker(ctx sdk.Context, k Keeper) (resTags sdk.Tags) {
 	}
 
 	// Update policy weights
+	updatedTaxCaps := k.updateTaxCaps(ctx)
 	taxRate := updateTaxPolicy(ctx, k)
 	rewardWeight := updateRewardPolicy(ctx, k)
 
@@ -35,5 +36,6 @@ func EndBlocker(ctx sdk.Context, k Keeper) (resTags sdk.Tags) {
 		tags.Action, tags.ActionPolicyUpdate,
 		tags.Tax, taxRate.String(),
 		tags.MinerReward, rewardWeight.String(),
+		tags.TaxCap, updatedTaxCaps.String(),
 	)
 }

--- a/x/treasury/tags/tags.go
+++ b/x/treasury/tags/tags.go
@@ -14,6 +14,7 @@ var (
 	Amount      = "amount"
 	Rewardee    = "rewardee"
 	Tax         = "tax"
+	TaxCap      = "tax-cap"
 	Class       = "class"
 	MinerReward = "miner-weight"
 	Oracle      = "oracle-reward"


### PR DESCRIPTION
**Summary of changes** 

* Remove tax for uluna sends and only retain them for stablecoin transfers
* Adjust tax cap every treasury policy adjustment for stablecoins (4 weeks) - cap should still be 1 SDT

Related Issue #175 

**Report of required housekeeping** 

- [x] Github issue OR spec proposal link
- [x] Wrote tests 
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

======

** (FOR ADMIN) Before merging ** 

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
