### PR TITLE
Bugfix/ Add staking hooks to track issuance change of luna

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -214,7 +214,7 @@ func NewTerraApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest,
 	// NOTE: The stakingKeeper above is passed by reference, so that it can be
 	// modified like below:
 	app.stakingKeeper = *stakingKeeper.SetHooks(
-		NewStakingHooks(app.distrKeeper.Hooks(), app.slashingKeeper.Hooks()))
+		NewStakingHooks(app.distrKeeper.Hooks(), app.slashingKeeper.Hooks(), app.mintKeeper.Hooks()))
 
 	// register the crisis routes
 	bank.RegisterInvariants(&app.crisisKeeper, app.accountKeeper)
@@ -458,11 +458,12 @@ var _ sdk.StakingHooks = StakingHooks{}
 type StakingHooks struct {
 	dh distr.Hooks
 	sh slashing.Hooks
+	mh mint.Hooks
 }
 
 // NewStakingHooks nolint
-func NewStakingHooks(dh distr.Hooks, sh slashing.Hooks) StakingHooks {
-	return StakingHooks{dh, sh}
+func NewStakingHooks(dh distr.Hooks, sh slashing.Hooks, mh mint.Hooks) StakingHooks {
+	return StakingHooks{dh, sh, mh}
 }
 
 // AfterValidatorCreated nolint
@@ -493,34 +494,40 @@ func (h StakingHooks) AfterValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAdd
 func (h StakingHooks) AfterValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
 	h.dh.AfterValidatorBeginUnbonding(ctx, consAddr, valAddr)
 	h.sh.AfterValidatorBeginUnbonding(ctx, consAddr, valAddr)
+	h.mh.AfterValidatorBeginUnbonding(ctx, consAddr, valAddr)
 }
 
 // BeforeDelegationCreated nolint
 func (h StakingHooks) BeforeDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 	h.dh.BeforeDelegationCreated(ctx, delAddr, valAddr)
 	h.sh.BeforeDelegationCreated(ctx, delAddr, valAddr)
+	h.mh.BeforeDelegationCreated(ctx, delAddr, valAddr)
 }
 
 // BeforeDelegationSharesModified nolint
 func (h StakingHooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 	h.dh.BeforeDelegationSharesModified(ctx, delAddr, valAddr)
 	h.sh.BeforeDelegationSharesModified(ctx, delAddr, valAddr)
+	h.mh.BeforeDelegationSharesModified(ctx, delAddr, valAddr)
 }
 
 // BeforeDelegationRemoved nolint
 func (h StakingHooks) BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 	h.dh.BeforeDelegationRemoved(ctx, delAddr, valAddr)
 	h.sh.BeforeDelegationRemoved(ctx, delAddr, valAddr)
+	h.mh.BeforeDelegationRemoved(ctx, delAddr, valAddr)
 }
 
 // AfterDelegationModified nolint
 func (h StakingHooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 	h.dh.AfterDelegationModified(ctx, delAddr, valAddr)
 	h.sh.AfterDelegationModified(ctx, delAddr, valAddr)
+	h.mh.AfterDelegationModified(ctx, delAddr, valAddr)
 }
 
 // BeforeValidatorSlashed nolint
 func (h StakingHooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {
 	h.dh.BeforeValidatorSlashed(ctx, valAddr, fraction)
 	h.sh.BeforeValidatorSlashed(ctx, valAddr, fraction)
+	h.mh.BeforeValidatorSlashed(ctx, valAddr, fraction)
 }

--- a/x/mint/hooks.go
+++ b/x/mint/hooks.go
@@ -1,0 +1,53 @@
+package mint
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Wrapper struct
+type Hooks struct {
+	k Keeper
+}
+
+var _ sdk.StakingHooks = Hooks{}
+
+// AfterValidatorCreated no-lint
+func (h Hooks) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {}
+
+// BeforeValidatorModified no-lint
+func (h Hooks) BeforeValidatorModified(ctx sdk.Context, valAddr sdk.ValAddress) {}
+
+// AfterValidatorRemoved no-lint
+func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+	h.k.SetIssuance(ctx)
+}
+
+// AfterValidatorBonded no-lint
+func (h Hooks) AfterValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+	h.k.SetIssuance(ctx)
+}
+
+// AfterValidatorBeginUnbonding no-lint
+func (h Hooks) AfterValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+	h.k.SetIssuance(ctx)
+}
+
+// BeforeDelegationCreated no-lint
+func (h Hooks) BeforeDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+}
+
+// BeforeDelegationSharesModified no-lint
+func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+}
+
+// BeforeDelegationRemoved no-lint
+func (h Hooks) BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+}
+
+// BeforeValidatorSlashed no-lint
+func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {}
+
+// AfterDelegationModified no-lint
+func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+	h.k.SetIssuance(ctx)
+}

--- a/x/treasury/test_common.go
+++ b/x/treasury/test_common.go
@@ -169,6 +169,8 @@ func createTestInput(t *testing.T) testInput {
 
 		distrKeeper.Hooks().AfterValidatorCreated(ctx, sdk.ValAddress(addr))
 		staking.EndBlocker(ctx, stakingKeeper)
+
+		mintKeeper.Hooks().AfterValidatorBonded(ctx, sdk.ConsAddress{}, sdk.ValAddress{})
 	}
 
 	oracleKeeper := oracle.NewKeeper(


### PR DESCRIPTION
** Summary of changes ** 

This PR change issuance tracker to refer staking pool's notBondedTokens and to update bonded denom(LUNA)'s issuance after staking hooks.

Related Issue #209 

** Report of required housekeeping ** 

- [x] Github issue OR spec proposal link
- [x] Wrote tests 
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

======

** (FOR ADMIN) Before merging ** 

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
