### PR TITLE
Feature/ Minor goreleaser changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.12.5
     steps:
       - checkout
       - run:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -90,12 +90,13 @@ builds:
       - goos: windows
         goarch: 386
 
-archive:
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    amd64: x86_64
+archives:
+  -
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
## Summary of changes

- Bump go version in the circleci `release` step to the same version used by the tests.
- Replace [deprecated](https://goreleaser.com/deprecations/#archive) `archive` directive.

Related to #206 

## Report of required housekeeping

- [x] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [x] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
