### PR TITLE
Disable macos circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,12 +425,12 @@ workflows:
                 - /.*/
           requires:
             - setup_dependencies
-      - macos_ci:
-          filters:
-            branches:
-              only:
-                - master
-                - develop
+      # - macos_ci:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      #           - develop
       # - deploy_docs:
       #     filters:
       #       branches:


### PR DESCRIPTION
## Summary of changes

It will disable macos circle ci. After upgrade circle ci plan, it will be enabled.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
