### PR TITLE
Fix `oracle/denoms/actives` example in swagger

### DIFF
--- a/client/lcd/swagger-ui/swagger.yaml
+++ b/client/lcd/swagger-ui/swagger.yaml
@@ -2329,7 +2329,7 @@ paths:
             type: array
             items:
               type: string
-            example: ["uluna", "usdr"]
+            example: ["ukrw", "usdr"]
         400:
           description: Bad Request
         500:


### PR DESCRIPTION
`uluna` will never figure in the response as it's the market oracle votes are based on.