### PR TITLE
[Bugfix] Register supply/ModuleAccount to auth ModuleCdc

### DIFF
--- a/x/auth/internal/types/codec.go
+++ b/x/auth/internal/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/supply"
 )
 
 // RegisterCodec registers concrete types on the codec
@@ -26,5 +27,6 @@ func init() {
 	ModuleCdc = codec.New()
 	RegisterCodec(ModuleCdc)
 	codec.RegisterCrypto(ModuleCdc)
+	ModuleCdc.RegisterConcrete(&supply.ModuleAccount{}, "supply/ModuleAccount", nil)
 	ModuleCdc.Seal()
 }


### PR DESCRIPTION
## Summary of changes

When we query module account to auth endpoint, it returns following error
```
terracli query account terra1jgp27m8fykex4e4jtt0l7ze8q528ux2lh4zh0f --trust-node
ERROR: unrecognized concrete type name supply/ModuleAccount
```

So we need to register supply/ModuleAccount to auth ModuleCdc for query end point.


## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
