### PR TITLE
shortened default oracle voteperiod to 30 seconds. 

### DIFF
--- a/x/oracle/internal/types/params.go
+++ b/x/oracle/internal/types/params.go
@@ -23,8 +23,8 @@ var (
 
 // Default parameter values
 const (
-	DefaultVotePeriod  = core.BlocksPerMinute // 1 minute
-	DefaultVotesWindow = int64(1000)          // 1000 oracle period
+	DefaultVotePeriod  = core.BlocksPerMinute / 2 // 30 seconds
+	DefaultVotesWindow = int64(1000)              // 1000 oracle period
 )
 
 // Default parameter values


### PR DESCRIPTION


## Summary of changes

We shortened the default oracle `VotePeriod` to 30 seconds. Action to @YunSuk-Yeo to reflect this change in the genfile (#244) in the next release  

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [x] Ensure all tests pass
