### PR TITLE
[Feature] Update treasury init genesis & oracle,market default params

### DIFF
--- a/x/market/alias.go
+++ b/x/market/alias.go
@@ -51,7 +51,6 @@ var (
 	ParmamStoreKeyTobinTax          = types.ParmamStoreKeyTobinTax
 	DefaultBasePool                 = types.DefaultBasePool
 	DefaultPoolRecoveryPeriod       = types.DefaultPoolRecoveryPeriod
-	DefaultTerraLiquidityRatio      = types.DefaultTerraLiquidityRatio
 	DefaultMinSpread                = types.DefaultMinSpread
 	DefaultTobinTax                 = types.DefaultTobinTax
 )

--- a/x/market/internal/types/params.go
+++ b/x/market/internal/types/params.go
@@ -26,11 +26,10 @@ var (
 
 // Default parameter values
 var (
-	DefaultBasePool            = sdk.NewDec(1000000 * core.MicroUnit) // 1000,000sdr = 1000,000,000,000usdr
-	DefaultPoolRecoveryPeriod  = core.BlocksPerDay                    // 14,400
-	DefaultTerraLiquidityRatio = sdk.NewDecWithPrec(1, 2)             // 1%
-	DefaultMinSpread           = sdk.NewDecWithPrec(2, 2)             // 2%
-	DefaultTobinTax            = sdk.NewDecWithPrec(30, 4)            // 0.3%
+	DefaultBasePool           = sdk.NewDec(250000 * core.MicroUnit) // 250,000sdr = 250,000,000,000usdr
+	DefaultPoolRecoveryPeriod = core.BlocksPerDay                   // 14,400
+	DefaultMinSpread          = sdk.NewDecWithPrec(2, 2)            // 2%
+	DefaultTobinTax           = sdk.NewDecWithPrec(25, 4)           // 0.25%
 )
 
 var _ subspace.ParamSet = &Params{}

--- a/x/oracle/internal/types/params.go
+++ b/x/oracle/internal/types/params.go
@@ -27,7 +27,7 @@ var (
 // Default parameter values
 const (
 	DefaultVotePeriod               = core.BlocksPerMinute / 2                // 30 seconds
-	DefaultSlashWindow              = core.BlocksPerHour / DefaultVotePeriod  // window for a hour
+	DefaultSlashWindow              = core.BlocksPerDay / DefaultVotePeriod   // window for a day
 	DefaultRewardDistributionWindow = core.BlocksPerMonth / DefaultVotePeriod // window for a month
 )
 

--- a/x/treasury/genesis.go
+++ b/x/treasury/genesis.go
@@ -12,8 +12,14 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
 
 	keeper.SetTaxRate(ctx, data.TaxRate)
 	keeper.SetRewardWeight(ctx, data.RewardWeight)
-	keeper.SetEpochInitialIssuance(ctx, data.EpochInitialIssuance)
 	keeper.SetEpochTaxProceeds(ctx, data.TaxProceed)
+
+	// If EpochInitialIssuance is empty, we use current supply as epoch initial issuance
+	if data.EpochInitialIssuance.Empty() {
+		keeper.RecordEpochInitialIssuance(ctx)
+	} else {
+		keeper.SetEpochInitialIssuance(ctx, data.EpochInitialIssuance)
+	}
 
 	// store tax caps
 	for denom, taxCap := range data.TaxCaps {

--- a/x/treasury/genesis_test.go
+++ b/x/treasury/genesis_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestExportInitGenesis(t *testing.T) {
 	input := keeper.CreateTestInput(t)
-	input.TreasuryKeeper.SetEpochInitialIssuance(input.Ctx, sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(33))))
+	input.TreasuryKeeper.RecordEpochInitialIssuance(input.Ctx)
 	input.TreasuryKeeper.SetRewardWeight(input.Ctx, sdk.NewDec(1123))
 	input.TreasuryKeeper.SetTaxCap(input.Ctx, "foo", sdk.NewInt(1234))
 	input.TreasuryKeeper.SetTaxRate(input.Ctx, sdk.NewDec(5435))
@@ -31,5 +31,17 @@ func TestExportInitGenesis(t *testing.T) {
 	InitGenesis(newInput.Ctx, newInput.TreasuryKeeper, genesis)
 	newGenesis := ExportGenesis(newInput.Ctx, newInput.TreasuryKeeper)
 
+	require.Equal(t, genesis, newGenesis)
+
+	// Make epoch initial issuance to zero
+	tmp := genesis.EpochInitialIssuance
+	genesis.EpochInitialIssuance = sdk.Coins{}
+
+	newInput = keeper.CreateTestInput(t)
+	InitGenesis(newInput.Ctx, newInput.TreasuryKeeper, genesis)
+	newGenesis = ExportGenesis(newInput.Ctx, newInput.TreasuryKeeper)
+
+	// Return back epoch initial issuance
+	genesis.EpochInitialIssuance = tmp
 	require.Equal(t, genesis, newGenesis)
 }


### PR DESCRIPTION
## Summary of changes

* Change treasury init genesis to use current supply when epoch initial issuance is empty
* Update default params of oracle and market module
  - `BasePool` of oracle: 250,000 SDT
  - `SlashWindow` of market: window for a day

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
