### PR TITLE
[Bugfix] Create oracle account at init genesis

### DIFF
--- a/x/market/internal/types/params.go
+++ b/x/market/internal/types/params.go
@@ -85,7 +85,7 @@ func (params *Params) ParamSetPairs() subspace.ParamSetPairs {
 // String implements fmt.Stringer interface
 func (params Params) String() string {
 	return fmt.Sprintf(`Treasury Params:
-	BasePool:                   %d
+	BasePool:                   %s
 	PoolRecoveryPeriod:         %d
 	MinSpread:                  %s
 	TobinTax:                   %s

--- a/x/oracle/genesis.go
+++ b/x/oracle/genesis.go
@@ -56,6 +56,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
 	}
 
 	keeper.SetParams(ctx, data.Params)
+	keeper.GetRewardPool(ctx)
 }
 
 // ExportGenesis writes the current store values

--- a/x/oracle/internal/keeper/keeper.go
+++ b/x/oracle/internal/keeper/keeper.go
@@ -258,8 +258,8 @@ func (k Keeper) IterateOracleDelegates(ctx sdk.Context,
 //-----------------------------------
 // Reward pool logic
 
-// getRewardPool retrieves the balance of the oracle module account
-func (k Keeper) getRewardPool(ctx sdk.Context) sdk.Coins {
+// GetRewardPool retrieves the balance of the oracle module account
+func (k Keeper) GetRewardPool(ctx sdk.Context) sdk.Coins {
 	acc := k.supplyKeeper.GetModuleAccount(ctx, types.ModuleName)
 	return acc.GetCoins()
 }

--- a/x/oracle/internal/keeper/keeper_test.go
+++ b/x/oracle/internal/keeper/keeper_test.go
@@ -229,7 +229,7 @@ func TestRewardPool(t *testing.T) {
 
 	input.SupplyKeeper.SetModuleAccount(input.Ctx, acc)
 
-	KFees := input.OracleKeeper.getRewardPool(input.Ctx)
+	KFees := input.OracleKeeper.GetRewardPool(input.Ctx)
 	require.Equal(t, fees, KFees)
 }
 

--- a/x/oracle/internal/keeper/reward.go
+++ b/x/oracle/internal/keeper/reward.go
@@ -24,7 +24,7 @@ func (k Keeper) RewardBallotWinners(ctx sdk.Context, ballotWinners map[string]ty
 		return
 	}
 
-	rewardPool := k.getRewardPool(ctx)
+	rewardPool := k.GetRewardPool(ctx)
 
 	// return if there's no rewards to give out
 	if rewardPool.Empty() {


### PR DESCRIPTION
## Summary of changes

* Crate oracle account at init genesis to prevent the the bank module make the oracle account address (`terra1jgp27m8fykex4e4jtt0l7ze8q528ux2lh4zh0f`) as general account.

close #292  

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
