### PR TITLE
[Feature] Prevent state reset of treasury after hard fork

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -17,15 +17,16 @@ import (
 func TestTerraExport(t *testing.T) {
 	db := dbm.NewMemDB()
 	tapp := NewTerraApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, 0)
-	setGenesis(tapp)
+	err := setGenesis(tapp)
+	require.NoError(t, err)
 
 	// Making a new app object with the db, so that initchain hasn't been called
 	newTapp := NewTerraApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, 0)
-	_, _, err := newTapp.ExportAppStateAndValidators(false, []string{})
-	require.NoError(t, err, "ExportAppStateAndValidators should not have an error")
+	_, _, err2 := newTapp.ExportAppStateAndValidators(false, []string{})
+	require.NoError(t, err2, "ExportAppStateAndValidators should not have an error")
 
-	_, _, err = newTapp.ExportAppStateAndValidators(true, []string{})
-	require.NoError(t, err, "ExportAppStateAndValidators for zero height should not have an error")
+	_, _, err2 = newTapp.ExportAppStateAndValidators(true, []string{})
+	require.NoError(t, err2, "ExportAppStateAndValidators for zero height should not have an error")
 }
 
 func setGenesis(tapp *TerraApp) error {

--- a/app/export.go
+++ b/app/export.go
@@ -198,10 +198,7 @@ func (app *TerraApp) prepForZeroHeightGenesis(ctx sdk.Context, jailWhiteList []s
 
 	/* Handle treasury state. */
 
-	// clear all indicators
-	app.treasuryKeeper.ClearTRs(ctx)
-	app.treasuryKeeper.ClearSRs(ctx)
-	app.treasuryKeeper.ClearTSLs(ctx)
-
-	app.treasuryKeeper.RecordEpochInitialIssuance(ctx)
+	// update cumulated height
+	newCumulatedHeight := app.treasuryKeeper.GetCumulatedHeight(ctx) + ctx.BlockHeight()
+	app.treasuryKeeper.SetCumulatedHeight(ctx, newCumulatedHeight)
 }

--- a/types/alias.go
+++ b/types/alias.go
@@ -27,7 +27,6 @@ const (
 	BlocksPerWeek        = util.BlocksPerWeek
 	BlocksPerMonth       = util.BlocksPerMonth
 	BlocksPerYear        = util.BlocksPerYear
-	BlocksPerEpoch       = util.BlocksPerEpoch
 	CoinType             = util.CoinType
 	FullFundraiserPath   = util.FullFundraiserPath
 	Bech32PrefixAccAddr  = util.Bech32PrefixAccAddr
@@ -40,6 +39,5 @@ const (
 
 var (
 	// functions aliases
-	GetEpoch          = util.GetEpoch
 	IsPeriodLastBlock = util.IsPeriodLastBlock
 )

--- a/types/util/blocks.go
+++ b/types/util/blocks.go
@@ -12,15 +12,7 @@ const (
 	BlocksPerWeek   = BlocksPerDay * 7
 	BlocksPerMonth  = BlocksPerDay * 30
 	BlocksPerYear   = BlocksPerDay * 365
-
-	BlocksPerEpoch = BlocksPerWeek
 )
-
-// GetEpoch returns the current epoch, starting from 0
-func GetEpoch(ctx sdk.Context) int64 {
-	curEpoch := ctx.BlockHeight() / BlocksPerEpoch
-	return curEpoch
-}
 
 // IsPeriodLastBlock returns true if we are at the last block of the period
 func IsPeriodLastBlock(ctx sdk.Context, blocksPerPeriod int64) bool {

--- a/x/treasury/abci.go
+++ b/x/treasury/abci.go
@@ -12,7 +12,7 @@ import (
 func EndBlocker(ctx sdk.Context, k Keeper) {
 
 	// Check epoch last block
-	if !core.IsPeriodLastBlock(ctx, core.BlocksPerEpoch) {
+	if !core.IsPeriodLastBlock(ctx, core.BlocksPerWeek) {
 		return
 	}
 
@@ -23,7 +23,7 @@ func EndBlocker(ctx sdk.Context, k Keeper) {
 	k.UpdateIndicators(ctx)
 
 	// Check probation period
-	if ctx.BlockHeight() < (core.BlocksPerEpoch * k.WindowProbation(ctx)) {
+	if ctx.BlockHeight() < (core.BlocksPerWeek * k.WindowProbation(ctx)) {
 		return
 	}
 

--- a/x/treasury/abci_test.go
+++ b/x/treasury/abci_test.go
@@ -22,7 +22,7 @@ func TestEndBlockerIssuanceUpdate(t *testing.T) {
 	input.SupplyKeeper.SetModuleAccount(input.Ctx, bondedModuleAcc)
 
 	targetIssuance := sdk.NewInt(1000)
-	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch - 1)
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek - 1)
 	supply := input.SupplyKeeper.GetSupply(input.Ctx)
 	supply = supply.SetTotal(sdk.NewCoins(sdk.NewCoin(core.MicroLunaDenom, targetIssuance)))
 	input.SupplyKeeper.SetSupply(input.Ctx, supply)
@@ -45,7 +45,7 @@ func TestUpdate(t *testing.T) {
 
 	targetEpoch := windowProbation + 1
 	for epoch := int64(0); epoch < targetEpoch; epoch++ {
-		input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch*epoch - 1)
+		input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek*epoch - 1)
 		EndBlocker(input.Ctx, input.TreasuryKeeper)
 	}
 
@@ -53,7 +53,7 @@ func TestUpdate(t *testing.T) {
 	taxRate := input.TreasuryKeeper.GetTaxRate(input.Ctx)
 	rewardWeight := input.TreasuryKeeper.GetRewardWeight(input.Ctx)
 
-	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch*targetEpoch - 1)
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek*targetEpoch - 1)
 	EndBlocker(input.Ctx, input.TreasuryKeeper)
 
 	// zero tax proceeds will increase tax rate with change max amount

--- a/x/treasury/alias.go
+++ b/x/treasury/alias.go
@@ -44,6 +44,9 @@ var (
 	NewTaxRateUpdateProposal      = types.NewTaxRateUpdateProposal
 	NewRewardWeightUpdateProposal = types.NewRewardWeightUpdateProposal
 	NewQueryTaxCapParams          = types.NewQueryTaxCapParams
+	TRL                           = keeper.TRL
+	SR                            = keeper.SR
+	MR                            = keeper.MR
 	NewKeeper                     = keeper.NewKeeper
 	ParamKeyTable                 = keeper.ParamKeyTable
 	NewQuerier                    = keeper.NewQuerier
@@ -55,6 +58,7 @@ var (
 	TaxCapKey                            = types.TaxCapKey
 	TaxProceedsKey                       = types.TaxProceedsKey
 	EpochInitialIssuanceKey              = types.EpochInitialIssuanceKey
+	CumulatedHeightKey                   = types.CumulatedHeightKey
 	TRKey                                = types.TRKey
 	SRKey                                = types.SRKey
 	TSLKey                               = types.TSLKey

--- a/x/treasury/genesis_test.go
+++ b/x/treasury/genesis_test.go
@@ -25,6 +25,7 @@ func TestExportInitGenesis(t *testing.T) {
 	input.TreasuryKeeper.SetTSL(input.Ctx, int64(0), sdk.NewInt(123))
 	input.TreasuryKeeper.SetTSL(input.Ctx, int64(1), sdk.NewInt(345))
 	input.TreasuryKeeper.SetTSL(input.Ctx, int64(2), sdk.NewInt(567))
+	input.TreasuryKeeper.SetCumulatedHeight(input.Ctx, int64(123))
 	genesis := ExportGenesis(input.Ctx, input.TreasuryKeeper)
 
 	newInput := keeper.CreateTestInput(t)

--- a/x/treasury/internal/keeper/indicator_test.go
+++ b/x/treasury/internal/keeper/indicator_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	core "github.com/terra-project/core/types"
-
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -33,7 +32,7 @@ func TestFeeRewardsForEpoch(t *testing.T) {
 	input.TreasuryKeeper.UpdateIndicators(input.Ctx)
 
 	// Get Tax Rawards (TR)
-	TR := input.TreasuryKeeper.GetTR(input.Ctx, core.GetEpoch(input.Ctx))
+	TR := input.TreasuryKeeper.GetTR(input.Ctx, input.TreasuryKeeper.GetEpoch(input.Ctx))
 	require.Equal(t, sdk.NewDec(1111).MulInt64(core.MicroUnit), TR)
 }
 
@@ -51,7 +50,7 @@ func TestSeigniorageRewardsForEpoch(t *testing.T) {
 
 	// Set random prices
 	input.OracleKeeper.SetLunaExchangeRate(input.Ctx, core.MicroSDRDenom, lnasdrRate)
-	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch)
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek)
 
 	// Add seigniorage
 	supply = supply.SetTotal(sdk.NewCoins(sdk.NewCoin(core.MicroLunaDenom, sdk.ZeroInt())))
@@ -61,7 +60,7 @@ func TestSeigniorageRewardsForEpoch(t *testing.T) {
 	input.TreasuryKeeper.UpdateIndicators(input.Ctx)
 
 	// Get seigniorage rewards (SR)
-	SR := input.TreasuryKeeper.GetSR(input.Ctx, core.GetEpoch(input.Ctx))
+	SR := input.TreasuryKeeper.GetSR(input.Ctx, input.TreasuryKeeper.GetEpoch(input.Ctx))
 	miningRewardWeight := input.TreasuryKeeper.GetRewardWeight(input.Ctx)
 	require.Equal(t, lnasdrRate.MulInt(sAmt).Mul(miningRewardWeight), SR)
 }
@@ -81,7 +80,7 @@ func TestMiningRewardsForEpoch(t *testing.T) {
 	input.OracleKeeper.SetLunaExchangeRate(input.Ctx, core.MicroGBPDenom, sdk.NewDec(100))
 	input.OracleKeeper.SetLunaExchangeRate(input.Ctx, core.MicroCNYDenom, sdk.NewDec(1000))
 
-	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch)
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek)
 
 	// Record tax proceeds
 	input.TreasuryKeeper.RecordEpochTaxProceeds(input.Ctx, sdk.Coins{
@@ -97,7 +96,7 @@ func TestMiningRewardsForEpoch(t *testing.T) {
 
 	input.TreasuryKeeper.UpdateIndicators(input.Ctx)
 
-	epoch := core.GetEpoch(input.Ctx)
+	epoch := input.TreasuryKeeper.GetEpoch(input.Ctx)
 
 	tProceeds := input.TreasuryKeeper.GetTR(input.Ctx, epoch)
 	sProceeds := input.TreasuryKeeper.GetSR(input.Ctx, epoch)
@@ -179,7 +178,7 @@ func TestSumIndicator(t *testing.T) {
 	require.Equal(t, sdk.ZeroDec(), rval)
 
 	// Case 3: at epoch 3 and summing over 3, 4, 5 epochs; all should have the same rval
-	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch * 3)
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek * 3)
 	rval = input.TreasuryKeeper.sumIndicator(input.Ctx, 4, SR)
 	rval2 := input.TreasuryKeeper.sumIndicator(input.Ctx, 5, SR)
 	rval3 := input.TreasuryKeeper.sumIndicator(input.Ctx, 6, SR)
@@ -192,7 +191,7 @@ func TestSumIndicator(t *testing.T) {
 	require.Equal(t, sdk.ZeroDec(), rval)
 
 	// Case 5. Sum up to 6
-	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch * 5)
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek * 5)
 	rval = input.TreasuryKeeper.sumIndicator(input.Ctx, 6, SR)
 	require.Equal(t, sdk.NewDec(2100), rval)
 }
@@ -219,7 +218,7 @@ func TestRollingAverageIndicator(t *testing.T) {
 	require.Equal(t, sdk.ZeroDec(), rval)
 
 	// Case 3: at epoch 3 and averaging over 3, 4, 5 epochs; all should have the same rval
-	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch * 3)
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek * 3)
 	rval = input.TreasuryKeeper.rollingAverageIndicator(input.Ctx, 4, SR)
 	rval2 := input.TreasuryKeeper.rollingAverageIndicator(input.Ctx, 5, SR)
 	rval3 := input.TreasuryKeeper.rollingAverageIndicator(input.Ctx, 6, SR)

--- a/x/treasury/internal/keeper/keeper.go
+++ b/x/treasury/internal/keeper/keeper.go
@@ -219,6 +219,26 @@ func (k Keeper) PeekEpochSeigniorage(ctx sdk.Context) sdk.Int {
 	return epochSeigniorage
 }
 
+// GetCumulatedHeight returns last block height of past chain
+func (k Keeper) GetCumulatedHeight(ctx sdk.Context) (res int64) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.CumulatedHeightKey)
+
+	if bz == nil {
+		res = 0
+	} else {
+		k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &res)
+	}
+	return
+}
+
+// SetCumulatedHeight sets cumulated block height of past chains
+func (k Keeper) SetCumulatedHeight(ctx sdk.Context, cumulatedHeight int64) {
+	store := ctx.KVStore(k.storeKey)
+	b := k.cdc.MustMarshalBinaryLengthPrefixed(cumulatedHeight)
+	store.Set(types.CumulatedHeightKey, b)
+}
+
 // GetTR returns the tax rewards for the epoch
 func (k Keeper) GetTR(ctx sdk.Context, epoch int64) (res sdk.Dec) {
 	store := ctx.KVStore(k.storeKey)

--- a/x/treasury/internal/keeper/keeper_test.go
+++ b/x/treasury/internal/keeper/keeper_test.go
@@ -90,7 +90,7 @@ func TestMicroLunaIssuance(t *testing.T) {
 	input.SupplyKeeper.SetSupply(input.Ctx, supply)
 
 	// See that we can get and set luna issuance
-	blocksPerEpoch := core.BlocksPerEpoch
+	blocksPerEpoch := core.BlocksPerWeek
 	for i := int64(0); i < 10; i++ {
 		input.Ctx = input.Ctx.WithBlockHeight(i * blocksPerEpoch)
 
@@ -106,7 +106,7 @@ func TestPeekEpochSeigniorage(t *testing.T) {
 	input := CreateTestInput(t)
 
 	for i := int64(0); i < 10; i++ {
-		input.Ctx = input.Ctx.WithBlockHeight(i * core.BlocksPerEpoch)
+		input.Ctx = input.Ctx.WithBlockHeight(i * core.BlocksPerWeek)
 		supply := input.SupplyKeeper.GetSupply(input.Ctx)
 
 		preIssuance := sdk.NewInt(rand.Int63() + 1)
@@ -124,6 +124,16 @@ func TestPeekEpochSeigniorage(t *testing.T) {
 		}
 
 		require.Equal(t, targetSeigniorage, input.TreasuryKeeper.PeekEpochSeigniorage(input.Ctx))
+	}
+}
+
+func TestCumulatedHeight(t *testing.T) {
+	input := CreateTestInput(t)
+
+	// See that we can get and set reward weights
+	for i := int64(0); i < 10; i++ {
+		input.TreasuryKeeper.SetCumulatedHeight(input.Ctx, i*100)
+		require.Equal(t, i*100, input.TreasuryKeeper.GetCumulatedHeight(input.Ctx))
 	}
 }
 

--- a/x/treasury/internal/keeper/policy_test.go
+++ b/x/treasury/internal/keeper/policy_test.go
@@ -31,7 +31,7 @@ func TestUpdateTaxRate(t *testing.T) {
 
 	// zero reward tax proceeds
 	for i := int64(0); i < windowLong; i++ {
-		input.Ctx = input.Ctx.WithBlockHeight(i * core.BlocksPerEpoch)
+		input.Ctx = input.Ctx.WithBlockHeight(i * core.BlocksPerWeek)
 
 		taxProceeds := sdk.NewCoins(sdk.NewCoin(core.MicroSDRDenom, sdk.ZeroInt()))
 		input.TreasuryKeeper.RecordEpochTaxProceeds(input.Ctx, taxProceeds)

--- a/x/treasury/internal/keeper/querier.go
+++ b/x/treasury/internal/keeper/querier.go
@@ -5,7 +5,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	core "github.com/terra-project/core/types"
 	"github.com/terra-project/core/x/treasury/internal/types"
 )
 
@@ -32,7 +31,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryCurrentEpoch(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
-	curEpoch := core.GetEpoch(ctx)
+	curEpoch := keeper.GetEpoch(ctx)
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, curEpoch)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/x/treasury/internal/keeper/querier_test.go
+++ b/x/treasury/internal/keeper/querier_test.go
@@ -144,7 +144,7 @@ func TestQueryRewardWeight(t *testing.T) {
 	rewardWeight := sdk.NewDecWithPrec(77, 2)
 	input.TreasuryKeeper.SetRewardWeight(input.Ctx, rewardWeight)
 
-	queriedRewardWeight := getQueriedRewardWeight(t, input.Ctx, input.Cdc, querier, core.GetEpoch(input.Ctx))
+	queriedRewardWeight := getQueriedRewardWeight(t, input.Ctx, input.Cdc, querier, input.TreasuryKeeper.GetEpoch(input.Ctx))
 
 	require.Equal(t, queriedRewardWeight, rewardWeight)
 }
@@ -156,7 +156,7 @@ func TestQueryTaxRate(t *testing.T) {
 	taxRate := sdk.NewDecWithPrec(1, 3)
 	input.TreasuryKeeper.SetTaxRate(input.Ctx, taxRate)
 
-	queriedTaxRate := getQueriedTaxRate(t, input.Ctx, input.Cdc, querier, core.GetEpoch(input.Ctx))
+	queriedTaxRate := getQueriedTaxRate(t, input.Ctx, input.Cdc, querier, input.TreasuryKeeper.GetEpoch(input.Ctx))
 
 	require.Equal(t, queriedTaxRate, taxRate)
 }
@@ -182,7 +182,7 @@ func TestQueryTaxProceeds(t *testing.T) {
 	}
 	input.TreasuryKeeper.RecordEpochTaxProceeds(input.Ctx, taxProceeds)
 
-	queriedTaxProceeds := getQueriedTaxProceeds(t, input.Ctx, input.Cdc, querier, core.GetEpoch(input.Ctx))
+	queriedTaxProceeds := getQueriedTaxProceeds(t, input.Ctx, input.Cdc, querier, input.TreasuryKeeper.GetEpoch(input.Ctx))
 
 	require.Equal(t, queriedTaxProceeds, taxProceeds)
 }
@@ -198,11 +198,11 @@ func TestQuerySeigniorageProceeds(t *testing.T) {
 	input.SupplyKeeper.SetSupply(input.Ctx, supply)
 	input.TreasuryKeeper.RecordEpochInitialIssuance(input.Ctx)
 
-	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch)
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek)
 	supply = supply.SetTotal(sdk.NewCoins(sdk.NewCoin(core.MicroLunaDenom, targetIssuance.Sub(targetSeigniorage))))
 	input.SupplyKeeper.SetSupply(input.Ctx, supply)
 
-	queriedSeigniorageProceeds := getQueriedSeigniorageProceeds(t, input.Ctx, input.Cdc, querier, core.GetEpoch(input.Ctx))
+	queriedSeigniorageProceeds := getQueriedSeigniorageProceeds(t, input.Ctx, input.Cdc, querier, input.TreasuryKeeper.GetEpoch(input.Ctx))
 
 	require.Equal(t, targetSeigniorage, queriedSeigniorageProceeds)
 }

--- a/x/treasury/internal/keeper/seigniorage_test.go
+++ b/x/treasury/internal/keeper/seigniorage_test.go
@@ -20,7 +20,7 @@ func TestSettle(t *testing.T) {
 	input.SupplyKeeper.SetSupply(input.Ctx, supply)
 	input.TreasuryKeeper.RecordEpochInitialIssuance(input.Ctx)
 
-	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerEpoch)
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek)
 	supply = supply.SetTotal(sdk.NewCoins(sdk.NewCoin(core.MicroLunaDenom, sdk.ZeroInt())))
 	input.SupplyKeeper.SetSupply(input.Ctx, supply)
 

--- a/x/treasury/internal/types/genesis_test.go
+++ b/x/treasury/internal/types/genesis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	core "github.com/terra-project/core/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -12,7 +13,7 @@ func TestGenesisValidation(t *testing.T) {
 	genState := DefaultGenesisState()
 	require.NoError(t, ValidateGenesis(genState))
 
-	// Error - tax-rate range error
+	// Error - tax_rate range error
 	genState.TaxRate = sdk.NewDec(-1)
 	require.Error(t, ValidateGenesis(genState))
 
@@ -20,9 +21,36 @@ func TestGenesisValidation(t *testing.T) {
 	genState.TaxRate = sdk.NewDecWithPrec(1, 2)
 	require.NoError(t, ValidateGenesis(genState))
 
-	// Error - reward-weight range error
+	// Error - reward_weight range error
 	genState.RewardWeight = sdk.NewDec(-1)
 	require.Error(t, ValidateGenesis(genState))
+
+	// Valid
+	genState.RewardWeight = sdk.NewDecWithPrec(5, 2)
+	require.NoError(t, ValidateGenesis(genState))
+
+	// Error - cumulated_height range error
+	genState.CumulatedHeight = -1
+	require.Error(t, ValidateGenesis(genState))
+
+	// Error - cumulated_height indicates 2 epoch, but stored TRs is smaller than 2
+	genState.CumulatedHeight = 2 * core.BlocksPerWeek
+	require.Error(t, ValidateGenesis(genState))
+
+	dummyDec := sdk.NewDec(10)
+	dummyInt := sdk.NewInt(10)
+
+	// Error - cumulated_height indicates 2 epoch, but stored SRs is smaller than 2
+	genState.TRs = []sdk.Dec{dummyDec, dummyDec}
+	require.Error(t, ValidateGenesis(genState))
+
+	// Error - cumulated_height indicates 2 epoch, but stored TSLs is smaller than 2
+	genState.SRs = []sdk.Dec{dummyDec, dummyDec}
+	require.Error(t, ValidateGenesis(genState))
+
+	// Valid
+	genState.TSLs = []sdk.Int{dummyInt, dummyInt}
+	require.NoError(t, ValidateGenesis(genState))
 }
 
 func TestGenesisEqual(t *testing.T) {

--- a/x/treasury/internal/types/keys.go
+++ b/x/treasury/internal/types/keys.go
@@ -36,6 +36,8 @@ const (
 // - 0x07<epoch_Bytes>: sdk.Dec
 //
 // - 0x08<epoch_Bytes>: sdk.Int
+//
+// - 0x09: int64
 var (
 	// Keys for store prefixes
 	TaxRateKey              = []byte{0x01} // a key for a tax-rate
@@ -43,6 +45,7 @@ var (
 	TaxCapKey               = []byte{0x03} // prefix for each key to a tax-cap
 	TaxProceedsKey          = []byte{0x04} // a key for a tax-proceeds
 	EpochInitialIssuanceKey = []byte{0x05} // a key for a initial epoch issuance
+	CumulatedHeightKey      = []byte{0x09} // a key for a cumulated height
 
 	// Keys for store prefixes of internal purpose variables
 	TRKey  = []byte{0x06} // prefix for each key to a TR


### PR DESCRIPTION
## Summary of changes

Now we introduce `CumulatedHeight` to keep indicator histories which are stored per each epoch even if the block height is reset (at hard fork). 

When we export genesis for zero height, it will update `CumulatedHeight` to `CumulatedHeight` + `ctx.BlockHeight()` for next chain without deleting indicator histories.

close #317 

## Report of required housekeeping

- [x] Github issue OR spec proposal link
- [x] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [x] Added appropriate labels to PR
- [x] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [x] Confirm added tests are consistent with the intended behavior of changes
- [x] Ensure all tests pass
