### PR TITLE
[Bugfix] Fix market swap handler to properly treat zero spread case

### DIFF
--- a/x/market/handler.go
+++ b/x/market/handler.go
@@ -58,6 +58,8 @@ func handleMsgSwap(ctx sdk.Context, k Keeper, ms MsgSwap) sdk.Result {
 			swapFee = sdk.NewDecCoinFromDec(swapCoin.Denom, swapFeeAmt)
 			swapCoin = swapCoin.Sub(swapFee)
 		}
+	} else {
+		swapFee = sdk.NewDecCoin(swapCoin.Denom, sdk.ZeroInt())
 	}
 
 	// Burn offered coins and subtract from the trader's account

--- a/x/market/handler_test.go
+++ b/x/market/handler_test.go
@@ -43,7 +43,16 @@ func TestSwapMsg(t *testing.T) {
 	price, _ := input.OracleKeeper.GetLunaExchangeRate(input.Ctx, core.MicroSDRDenom)
 	require.Equal(t, price.MulInt(amt), diff.Abs())
 
+	// invalid recursive swap
 	swapMsg = NewMsgSwap(keeper.Addrs[0], offerCoin, core.MicroLunaDenom)
 	res = h(input.Ctx, swapMsg)
 	require.False(t, res.IsOK())
+
+	// valid zero tobin tax test
+	input.OracleKeeper.SetTobinTax(input.Ctx, core.MicroKRWDenom, sdk.ZeroDec())
+	input.OracleKeeper.SetTobinTax(input.Ctx, core.MicroSDRDenom, sdk.ZeroDec())
+	offerCoin = sdk.NewCoin(core.MicroSDRDenom, amt)
+	swapMsg = NewMsgSwap(keeper.Addrs[0], offerCoin, core.MicroKRWDenom)
+	res = h(input.Ctx, swapMsg)
+	require.True(t, res.IsOK())
 }

--- a/x/market/test_utils.go
+++ b/x/market/test_utils.go
@@ -22,6 +22,7 @@ func setup(t *testing.T) (keeper.TestInput, sdk.Handler) {
 	params := input.MarketKeeper.GetParams(input.Ctx)
 	input.MarketKeeper.SetParams(input.Ctx, params)
 	input.OracleKeeper.SetLunaExchangeRate(input.Ctx, core.MicroSDRDenom, randomPrice)
+	input.OracleKeeper.SetLunaExchangeRate(input.Ctx, core.MicroKRWDenom, randomPrice)
 	h := NewHandler(input.MarketKeeper)
 
 	return input, h


### PR DESCRIPTION
## Summary of changes

Current market handler crash when it meets zero tobin tax denom(not possible, under columbus-3). This release will prevent crash for the swap between zero tobin tax denoms.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [x] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [x] Added appropriate labels to PR
- [x] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [x] Confirm added tests are consistent with the intended behavior of changes
- [x] Ensure all tests pass
