### PR TITLE
[Bugfix] WASM module codec naming

### DIFF
--- a/x/wasm/internal/types/codec.go
+++ b/x/wasm/internal/types/codec.go
@@ -6,11 +6,11 @@ import (
 
 // RegisterCodec registers the wasm types and interface
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterConcrete(MsgStoreCode{}, "wasm/StoreCode", nil)
-	cdc.RegisterConcrete(MsgInstantiateContract{}, "wasm/InstantiateContract", nil)
-	cdc.RegisterConcrete(MsgExecuteContract{}, "wasm/ExecuteContract", nil)
-	cdc.RegisterConcrete(MsgMigrateContract{}, "wasm/MigrateContract", nil)
-	cdc.RegisterConcrete(MsgUpdateContractOwner{}, "wasm/UpdateContractOwner", nil)
+	cdc.RegisterConcrete(MsgStoreCode{}, "wasm/MsgStoreCode", nil)
+	cdc.RegisterConcrete(MsgInstantiateContract{}, "wasm/MsgInstantiateContract", nil)
+	cdc.RegisterConcrete(MsgExecuteContract{}, "wasm/MsgExecuteContract", nil)
+	cdc.RegisterConcrete(MsgMigrateContract{}, "wasm/MsgMigrateContract", nil)
+	cdc.RegisterConcrete(MsgUpdateContractOwner{}, "wasm/MsgUpdateContractOwner", nil)
 }
 
 // ModuleCdc generic sealed codec to be used throughout module

--- a/x/wasm/internal/types/msg.go
+++ b/x/wasm/internal/types/msg.go
@@ -92,7 +92,7 @@ func (msg MsgInstantiateContract) Type() string {
 // ValidateBasic implements sdk.Msg
 func (msg MsgInstantiateContract) ValidateBasic() error {
 	if msg.Owner.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing sender")
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing owner")
 	}
 
 	if !msg.InitCoins.IsValid() {


### PR DESCRIPTION
## Summary of changes

* Change WASM related msg codec names  to Msg* for consistency

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
