### PR TITLE
fix: stringify yes and no map keys

### DIFF
--- a/client/lcd/swagger-ui/swagger.yaml
+++ b/client/lcd/swagger-ui/swagger.yaml
@@ -3461,13 +3461,13 @@ definitions:
   TallyResult:
     type: object
     properties:
-      yes:
+      'yes':
         type: string
         example: "0.0000000000"
       abstain:
         type: string
         example: "0.0000000000"
-      no:
+      'no':
         type: string
         example: "0.0000000000"
       no_with_veto:


### PR DESCRIPTION
## Summary of changes

In swagger definition, `TallyResult` response properties has `yes` and `no` as map keys. These are treated respectively `true` and `false` in yaml spec (🤷‍♂️) . This makes spec compliant go yaml parser scream, as in golang maps cannot have `bool` type as keys.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated relevant documentation (docs/)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
