### PR TITLE
[Oracle] Exchange Rate and Ballot Rewards logic using reference terra

### DIFF
--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -53,51 +53,81 @@ func EndBlocker(ctx sdk.Context, k Keeper) {
 	// NOTE: **Make abstain votes to have zero vote power**
 	voteMap := k.OrganizeBallotByDenom(ctx)
 
-	// Iterate through ballots and update exchange rates; drop if not enough votes have been achieved.
-	for denom, ballot := range voteMap {
+	LargestBallotPower := int64(0)
+	var referenceTerra string
+	voteMapRT := make(map[string]sdk.Dec)
 
+	// choose Reference Terra with the highest voter turnout
+	// If the voting power of the two denominations is the same, select reference Terra in alphabetical order.
+	for denom, ballot := range voteMap {
 		// If denom is not in the voteTargets, or the ballot for it has failed, then skip
+		// and remove it from voteMap for iteration efficiency
 		if _, exists := voteTargets[denom]; !exists {
+			delete(voteMap, denom)
 			continue
 		}
+		ballotPower := ballot.Power()
 
 		// If the ballot is not passed, remove it from the voteTargets array
 		// to prevent slashing validators who did valid vote.
 		if !ballotIsPassing(ctx, ballot, k) {
 			delete(voteTargets, denom)
+			delete(voteMap, denom)
 			continue
 		}
 
-		// Get weighted median exchange rates, and faithful respondants
-		ballotMedian, ballotWinningClaims := tally(ctx, ballot, params.RewardBand)
-
-		// Set the exchange rate
-		k.SetLunaExchangeRate(ctx, denom, ballotMedian)
-
-		// Collect claims of ballot winners
-		for _, ballotWinningClaim := range ballotWinningClaims {
-
-			// NOTE: we directly stringify byte to string to prevent unnecessary bech32fy works
-			key := string(ballotWinningClaim.Recipient)
-
-			// Update claim
-			prevClaim := winnerMap[key]
-			prevClaim.Weight += ballotWinningClaim.Weight
-			winnerMap[key] = prevClaim
-
-			// Increase valid votes counter
-			validVotesCounterMap[key]++
+		if ballotPower > LargestBallotPower || LargestBallotPower == 0 {
+			referenceTerra = denom
+			LargestBallotPower = ballotPower
+		} else if LargestBallotPower == ballotPower && referenceTerra > denom {
+			referenceTerra = denom
 		}
-
-		// Emit abci events
-		ctx.EventManager().EmitEvent(
-			sdk.NewEvent(types.EventTypeExchangeRateUpdate,
-				sdk.NewAttribute(types.AttributeKeyDenom, denom),
-				sdk.NewAttribute(types.AttributeKeyExchangeRate, ballotMedian.String()),
-			),
-		)
 	}
 
+	if referenceTerra != "" {
+		// make voteMap of Reference Terra to calculate cross exchange rates
+		ballotRT, _ := voteMap[referenceTerra]
+		for _, vote := range ballotRT {
+			if vote.ExchangeRate.IsPositive() {
+				voteMapRT[string(vote.Voter)] = vote.ExchangeRate
+			}
+		}
+
+		// Get weighted median exchange rates of Reference Terra, and faithful respondants
+		ballotMedianRT, ballotWinningClaimsRT := tally(ctx, ballotRT, params.RewardBand)
+
+		// Set the exchange rate, emit ABCI event
+		k.SetLunaExchangeRateWithEvent(ctx, referenceTerra, ballotMedianRT)
+
+		// Handle Ballot Winner for Reference Terra
+		handleBallotWinner(ballotWinningClaimsRT, validVotesCounterMap, winnerMap)
+
+		// Iterate through ballots and update exchange rates; drop if not enough votes have been achieved.
+		for denom, ballot := range voteMap {
+			if denom == referenceTerra {
+				continue
+			}
+			// Ballot based cross exchange rates
+			var cerBallot types.ExchangeRateBallot
+			for _, vote := range ballot {
+				if exchangeRateRT, ok := voteMapRT[string(vote.Voter)]; ok {
+					vote.ExchangeRate = exchangeRateRT.Quo(vote.ExchangeRate)
+					cerBallot = append(cerBallot, vote)
+				}
+			}
+			// Get weighted median of cross exchange rates
+			cerMedian, ballotWinningClaims := tally(ctx, cerBallot, params.RewardBand)
+
+			// Handle Ballot Winner using cross exchange rate for not reference Terra
+			handleBallotWinner(ballotWinningClaims, validVotesCounterMap, winnerMap)
+
+			// Transform into the original form uluna/stablecoin
+			exchangeRateByRT := ballotMedianRT.Quo(cerMedian)
+
+			// Set the exchange rate, emit ABCI event
+			k.SetLunaExchangeRateWithEvent(ctx, denom, exchangeRateByRT)
+		}
+	}
 	//---------------------------
 	// Do miss counting & slashing
 	voteTargetsLen := len(voteTargets)

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -53,8 +53,8 @@ func EndBlocker(ctx sdk.Context, k Keeper) {
 	// NOTE: **Make abstain votes to have zero vote power**
 	voteMap := k.OrganizeBallotByDenom(ctx)
 
-	LargestBallotPower := int64(0)
 	var referenceTerra string
+	LargestBallotPower := int64(0)
 	voteMapRT := make(map[string]sdk.Dec)
 
 	// choose Reference Terra with the highest voter turnout
@@ -99,8 +99,8 @@ func EndBlocker(ctx sdk.Context, k Keeper) {
 		// Set the exchange rate, emit ABCI event
 		k.SetLunaExchangeRateWithEvent(ctx, referenceTerra, ballotMedianRT)
 
-		// Handle Ballot Winner for Reference Terra
-		handleBallotWinner(ballotWinningClaimsRT, validVotesCounterMap, winnerMap)
+		// Update winnerMap, validVotesCounterMap using ballotWinningClaims of Reference Terra ballot
+		updateWinnerMap(ballotWinningClaimsRT, validVotesCounterMap, winnerMap)
 
 		// Iterate through ballots and update exchange rates; drop if not enough votes have been achieved.
 		for denom, ballot := range voteMap {
@@ -118,8 +118,8 @@ func EndBlocker(ctx sdk.Context, k Keeper) {
 			// Get weighted median of cross exchange rates
 			cerMedian, ballotWinningClaims := tally(ctx, cerBallot, params.RewardBand)
 
-			// Handle Ballot Winner using cross exchange rate for not reference Terra
-			handleBallotWinner(ballotWinningClaims, validVotesCounterMap, winnerMap)
+			// Update winnerMap, validVotesCounterMap using ballotWinningClaims of cross exchange rate ballot
+			updateWinnerMap(ballotWinningClaims, validVotesCounterMap, winnerMap)
 
 			// Transform into the original form uluna/stablecoin
 			exchangeRateByRT := ballotMedianRT.Quo(cerMedian)

--- a/x/oracle/internal/keeper/keeper.go
+++ b/x/oracle/internal/keeper/keeper.go
@@ -196,6 +196,17 @@ func (k Keeper) SetLunaExchangeRate(ctx sdk.Context, denom string, exchangeRate 
 	store.Set(types.GetExchangeRateKey(denom), bz)
 }
 
+// SetLunaExchangeRate with Emit ABCI event
+func (k Keeper) SetLunaExchangeRateWithEvent(ctx sdk.Context, denom string, exchangeRate sdk.Dec) {
+	k.SetLunaExchangeRate(ctx, denom, exchangeRate)
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(types.EventTypeExchangeRateUpdate,
+			sdk.NewAttribute(types.AttributeKeyDenom, denom),
+			sdk.NewAttribute(types.AttributeKeyExchangeRate, exchangeRate.String()),
+		),
+	)
+}
+
 // DeleteLunaExchangeRate deletes the consensus exchange rate of Luna denominated in the denom asset from the store.
 func (k Keeper) DeleteLunaExchangeRate(ctx sdk.Context, denom string) {
 	store := ctx.KVStore(k.storeKey)

--- a/x/oracle/internal/keeper/test_utils.go
+++ b/x/oracle/internal/keeper/test_utils.go
@@ -32,18 +32,24 @@ var (
 		secp256k1.GenPrivKey().PubKey(),
 		secp256k1.GenPrivKey().PubKey(),
 		secp256k1.GenPrivKey().PubKey(),
+		secp256k1.GenPrivKey().PubKey(),
+		secp256k1.GenPrivKey().PubKey(),
 	}
 
 	Addrs = []sdk.AccAddress{
 		sdk.AccAddress(PubKeys[0].Address()),
 		sdk.AccAddress(PubKeys[1].Address()),
 		sdk.AccAddress(PubKeys[2].Address()),
+		sdk.AccAddress(PubKeys[3].Address()),
+		sdk.AccAddress(PubKeys[4].Address()),
 	}
 
 	ValAddrs = []sdk.ValAddress{
 		sdk.ValAddress(PubKeys[0].Address()),
 		sdk.ValAddress(PubKeys[1].Address()),
 		sdk.ValAddress(PubKeys[2].Address()),
+		sdk.ValAddress(PubKeys[3].Address()),
+		sdk.ValAddress(PubKeys[4].Address()),
 	}
 
 	InitTokens = sdk.TokensFromConsensusPower(200)

--- a/x/oracle/tally.go
+++ b/x/oracle/tally.go
@@ -40,7 +40,7 @@ func tally(ctx sdk.Context, pb types.ExchangeRateBallot, rewardBand sdk.Dec) (we
 	return
 }
 
-func handleBallotWinner(ballotWinningClaims []types.Claim, validVotesCounterMap map[string]int, winnerMap map[string]types.Claim) {
+func updateWinnerMap(ballotWinningClaims []types.Claim, validVotesCounterMap map[string]int, winnerMap map[string]types.Claim) {
 	// Collect claims of ballot winners
 	for _, ballotWinningClaim := range ballotWinningClaims {
 

--- a/x/oracle/tally.go
+++ b/x/oracle/tally.go
@@ -40,6 +40,23 @@ func tally(ctx sdk.Context, pb types.ExchangeRateBallot, rewardBand sdk.Dec) (we
 	return
 }
 
+func handleBallotWinner(ballotWinningClaims []types.Claim, validVotesCounterMap map[string]int, winnerMap map[string]types.Claim) {
+	// Collect claims of ballot winners
+	for _, ballotWinningClaim := range ballotWinningClaims {
+
+		// NOTE: we directly stringify byte to string to prevent unnecessary bech32fy works
+		key := string(ballotWinningClaim.Recipient)
+
+		// Update claim
+		prevClaim := winnerMap[key]
+		prevClaim.Weight += ballotWinningClaim.Weight
+		winnerMap[key] = prevClaim
+
+		// Increase valid votes counter
+		validVotesCounterMap[key]++
+	}
+}
+
 // ballot for the asset is passing the threshold amount of voting power
 func ballotIsPassing(ctx sdk.Context, ballot types.ExchangeRateBallot, k Keeper) bool {
 	totalBondedPower := sdk.TokensToConsensusPower(k.StakingKeeper.TotalBondedTokens(ctx))

--- a/x/oracle/test_utils.go
+++ b/x/oracle/test_utils.go
@@ -19,8 +19,6 @@ var (
 
 	randomExchangeRate        = sdk.NewDec(1700)
 	anotherRandomExchangeRate = sdk.NewDecWithPrec(4882, 2) // swap rate
-	krwRandomExchangeRate     = sdk.NewDecWithPrec(1000000000, int64(6)).MulInt64(core.MicroUnit)
-	uswRandomExchangeRate     = sdk.NewDecWithPrec(1000000, int64(6)).MulInt64(core.MicroUnit)
 )
 
 func setup_with_small_voting_power(t *testing.T) (keeper.TestInput, sdk.Handler) {
@@ -58,6 +56,33 @@ func setup(t *testing.T) (keeper.TestInput, sdk.Handler) {
 	_, err = sh(input.Ctx, keeper.NewTestMsgCreateValidator(keeper.ValAddrs[1], keeper.PubKeys[1], stakingAmt))
 	require.NoError(t, err)
 	_, err = sh(input.Ctx, keeper.NewTestMsgCreateValidator(keeper.ValAddrs[2], keeper.PubKeys[2], stakingAmt))
+	require.NoError(t, err)
+	staking.EndBlocker(input.Ctx, input.StakingKeeper)
+
+	return input, h
+}
+
+func setupVal5(t *testing.T) (keeper.TestInput, sdk.Handler) {
+	input := keeper.CreateTestInput(t)
+	params := input.OracleKeeper.GetParams(input.Ctx)
+	params.VotePeriod = 1
+	params.SlashWindow = 100
+	params.RewardDistributionWindow = 100
+	input.OracleKeeper.SetParams(input.Ctx, params)
+	h := NewHandler(input.OracleKeeper)
+
+	sh := staking.NewHandler(input.StakingKeeper)
+
+	// Validator created
+	_, err := sh(input.Ctx, keeper.NewTestMsgCreateValidator(keeper.ValAddrs[0], keeper.PubKeys[0], stakingAmt))
+	require.NoError(t, err)
+	_, err = sh(input.Ctx, keeper.NewTestMsgCreateValidator(keeper.ValAddrs[1], keeper.PubKeys[1], stakingAmt))
+	require.NoError(t, err)
+	_, err = sh(input.Ctx, keeper.NewTestMsgCreateValidator(keeper.ValAddrs[2], keeper.PubKeys[2], stakingAmt))
+	require.NoError(t, err)
+	_, err = sh(input.Ctx, keeper.NewTestMsgCreateValidator(keeper.ValAddrs[3], keeper.PubKeys[3], stakingAmt))
+	require.NoError(t, err)
+	_, err = sh(input.Ctx, keeper.NewTestMsgCreateValidator(keeper.ValAddrs[4], keeper.PubKeys[4], stakingAmt))
 	require.NoError(t, err)
 	staking.EndBlocker(input.Ctx, input.StakingKeeper)
 

--- a/x/oracle/test_utils.go
+++ b/x/oracle/test_utils.go
@@ -19,6 +19,8 @@ var (
 
 	randomExchangeRate        = sdk.NewDec(1700)
 	anotherRandomExchangeRate = sdk.NewDecWithPrec(4882, 2) // swap rate
+	krwRandomExchangeRate     = sdk.NewDecWithPrec(1000000000, int64(6)).MulInt64(core.MicroUnit)
+	uswRandomExchangeRate     = sdk.NewDecWithPrec(1000000, int64(6)).MulInt64(core.MicroUnit)
 )
 
 func setup_with_small_voting_power(t *testing.T) (keeper.TestInput, sdk.Handler) {


### PR DESCRIPTION
## Summary of changes

Follow-up of https://github.com/terra-project/core/pull/345#issuecomment-645142148, https://github.com/terra-project/core/pull/345#issuecomment-666961850

1. Add reference Terra
    - Let `Vote_j = Vote_j_1 ... Vote_j_n` be the `uluna` exchange rate votes for each terra for validator `Val_j` in a given `VotePeriod`. `n` = number of total terra whitelist
    - For all terra whitelist  `w_1 ... w_n`, choose the index `r` with the highest voter turnout. If the vote turnout has multiple tie winner, we choose in alphabetical order. `w_r` is chosen as the reference terra from which to compute cross exchange rates.
2. Fix Oracle Exchange Rate logic
    - Each validator now calculate cross exchange rates(`CER`) for `w_i` as below.
        - for `i≠r`, `CER_j_i = Vote_j_r / Vote_j_i`
        - for `i=r`, `CER_j_i = Vote_j_r`
    - Calculate power weighted median(`PWM`, across all validators) for each cross exchange rates `CER_j_iMCER_i` = `PWM`(for all j)[`CER_j_i`]
    - Now we transform these `MCER_i`s into the original form uluna/terra as below
        - for `i≠r`, `LunaRate_i = MCER_r / MCER_i`
        - for `i=r`, `LunaRate_i = MCER_r`
    - store this final result `LunaRate_i` into kv-store.
3. Fix Oracle Ballot Rewards logic
    - for `i=r`, same as before, reward ballot winners based `CER_j_i = Vote_j_r` ballot with `MCER_i` using existing `tally`
    - for `i≠r`,  reward ballot winners based `CER_j_i = Vote_j_r / Vote_j_i` ballot with `MCER_i` using existing `tally`
4. Add Test cases for fixed logic
    - Fix result, assert `TestOracleMultiRewardDistribution`
    - Add `TestOracleExchangeRate` , `TestOracleExchangeRateVal5`
    - Expand test validator set 5 in `x/oracle/test_utils.go` for `TestOracleExchangeRateVal5`
5. Refactoring
    - extract as a function `updateWinnerMap` that update winnerMap, validVotesCounterMap using given ballotWinningClaims
    - define `SetLunaExchangeRateWithEvent`
        - `SetLunaExchangeRate` with Emit ABCI event

## Report of required housekeeping

- [x] Github issue OR spec proposal link
- [x] Wrote tests
- [ ] Updated relevant documentation (docs/) ( TBD: after code confirmed )
- [x] Added a relevant changelog entry: clog add [section] [stanza] [message]

### Related links
- https://medium.com/@bharvest/terra-sdr-arbitrage-and-cross-rate-calculation-a77bfee70ca0
- https://github.com/terra-project/core/issues/342
- https://agora.terra.money/t/governance-temporarily-increase-tobin-tax-from-0-25-to-0-35/233
- https://github.com/terra-project/core/pull/345, https://github.com/terra-project/core/pull/345#issuecomment-645142148, https://github.com/terra-project/core/pull/345#issuecomment-666961850

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
