### PR TITLE
[Bugfix] Wasm instantiate process

### DIFF
--- a/x/wasm/internal/keeper/contract_test.go
+++ b/x/wasm/internal/keeper/contract_test.go
@@ -627,8 +627,8 @@ func TestMigrateWithDispatchedMessage(t *testing.T) {
 			},
 		},
 	}
-	expJsonEvts := string(mustMarshal(t, expEvents))
-	assert.JSONEq(t, expJsonEvts, prettyEvents(t, ctx.EventManager().Events()))
+	expJSONEvts := string(mustMarshal(t, expEvents))
+	assert.JSONEq(t, expJSONEvts, prettyEvents(t, ctx.EventManager().Events()))
 
 	// all persistent data cleared
 	m := keeper.queryToStore(ctx, contractAddr, []byte("config"))


### PR DESCRIPTION
## Summary of changes

Fix to store instantiated contract first before executing response messages, then response messages can utilize instantiated contract.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
