### PR TITLE
[Bugfix] allow language specific decimal precision error in vesting schedule validation

### DIFF
--- a/x/auth/vesting/types/schedule.go
+++ b/x/auth/vesting/types/schedule.go
@@ -144,7 +144,10 @@ func (vs VestingSchedule) Validate() error {
 		sumRatio = sumRatio.Add(lazySchedule.GetRatio())
 	}
 
-	if !sumRatio.Equal(sdk.OneDec()) {
+	// add rounding to allow language specific calculation errors
+	const fixedPointDecimals = 1000000000
+	if !sumRatio.MulInt64(fixedPointDecimals).RoundInt().
+		ToDec().QuoInt64(fixedPointDecimals).Equal(sdk.OneDec()) {
 		return errors.New("vesting total ratio must be one")
 	}
 


### PR DESCRIPTION
## Summary of changes

Minor decimal precision correction in vesting schedule validation.

close #418 

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
