### PR TITLE
[Bugfix] Register wasm queriers after staking keeper initialization

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -245,20 +245,6 @@ func NewTerraApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest 
 	// create wasm keeper with msg parser & querier
 	app.wasmKeeper = wasm.NewKeeper(app.cdc, keys[wasm.StoreKey], app.subspaces[wasm.ModuleName],
 		app.accountKeeper, app.bankKeeper, app.supplyKeeper, app.treasuryKeeper, bApp.Router(), wasm.DefaultFeatures, wasmConfig)
-	app.wasmKeeper.RegisterMsgParsers(map[string]wasm.WasmMsgParserInterface{
-		wasm.WasmMsgParserRouteBank:    bankwasm.NewWasmMsgParser(),
-		wasm.WasmMsgParserRouteStaking: stakingwasm.NewWasmMsgParser(),
-		wasm.WasmMsgParserRouteMarket:  marketwasm.NewWasmMsgParser(),
-		wasm.WasmMsgParserRouteWasm:    wasm.NewWasmMsgParser(),
-	})
-	app.wasmKeeper.RegisterQueriers(map[string]wasm.WasmQuerierInterface{
-		wasm.WasmQueryRouteBank:     bankwasm.NewWasmQuerier(app.bankKeeper),
-		wasm.WasmQueryRouteStaking:  stakingwasm.NewWasmQuerier(app.stakingKeeper),
-		wasm.WasmQueryRouteMarket:   marketwasm.NewWasmQuerier(app.marketKeeper),
-		wasm.WasmQueryRouteOracle:   oraclewasm.NewWasmQuerier(app.oracleKeeper),
-		wasm.WasmQueryRouteTreasury: treasurywasm.NewWasmQuerier(app.treasuryKeeper),
-		wasm.WasmQueryRouteWasm:     wasm.NewWasmQuerier(app.wasmKeeper),
-	})
 
 	// register the proposal types
 	govRouter := gov.NewRouter()
@@ -274,6 +260,21 @@ func NewTerraApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest 
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
 	app.stakingKeeper = *stakingKeeper.SetHooks(
 		staking.NewMultiStakingHooks(app.distrKeeper.Hooks(), app.slashingKeeper.Hooks()))
+
+	app.wasmKeeper.RegisterMsgParsers(map[string]wasm.WasmMsgParserInterface{
+		wasm.WasmMsgParserRouteBank:    bankwasm.NewWasmMsgParser(),
+		wasm.WasmMsgParserRouteStaking: stakingwasm.NewWasmMsgParser(),
+		wasm.WasmMsgParserRouteMarket:  marketwasm.NewWasmMsgParser(),
+		wasm.WasmMsgParserRouteWasm:    wasm.NewWasmMsgParser(),
+	})
+	app.wasmKeeper.RegisterQueriers(map[string]wasm.WasmQuerierInterface{
+		wasm.WasmQueryRouteBank:     bankwasm.NewWasmQuerier(app.bankKeeper),
+		wasm.WasmQueryRouteStaking:  stakingwasm.NewWasmQuerier(app.stakingKeeper),
+		wasm.WasmQueryRouteMarket:   marketwasm.NewWasmQuerier(app.marketKeeper),
+		wasm.WasmQueryRouteOracle:   oraclewasm.NewWasmQuerier(app.oracleKeeper),
+		wasm.WasmQueryRouteTreasury: treasurywasm.NewWasmQuerier(app.treasuryKeeper),
+		wasm.WasmQueryRouteWasm:     wasm.NewWasmQuerier(app.wasmKeeper),
+	})
 
 	app.mm = module.NewManager(
 		genutil.NewAppModule(app.accountKeeper, app.stakingKeeper, app.BaseApp.DeliverTx),


### PR DESCRIPTION
## Summary of changes

* Register wasm queriers after initializing staking keeper

close #428 

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
