### PR TITLE
[Bugfix] Prevent panic when external contract query executed

### DIFF
--- a/x/wasm/internal/keeper/recursive_test.go
+++ b/x/wasm/internal/keeper/recursive_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerror "github.com/cosmos/cosmos-sdk/types/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/terra-project/core/x/wasm/internal/types"
@@ -251,11 +252,9 @@ func TestGasOnExternalQuery(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.expectPanic {
-				require.Panics(t, func() {
-					// this should run out of gas
-					_, err = querier(ctx, []string{types.QueryContractStore}, abci.RequestQuery{Data: []byte(bz)})
-					t.Logf("%v", err)
-				})
+				_, err = querier(ctx, []string{types.QueryContractStore}, abci.RequestQuery{Data: []byte(bz)})
+				require.Error(t, err)
+				require.Equal(t, err, sdkerror.ErrOutOfGas)
 			} else {
 				// otherwise, make sure we get a good success
 				_, err = querier(ctx, []string{types.QueryContractStore}, abci.RequestQuery{Data: []byte(bz)})

--- a/x/wasm/internal/keeper/recursive_test.go
+++ b/x/wasm/internal/keeper/recursive_test.go
@@ -254,7 +254,7 @@ func TestGasOnExternalQuery(t *testing.T) {
 			if tc.expectPanic {
 				_, err = querier(ctx, []string{types.QueryContractStore}, abci.RequestQuery{Data: []byte(bz)})
 				require.Error(t, err)
-				require.Equal(t, err, sdkerror.ErrOutOfGas)
+				require.Contains(t, err.Error(), sdkerror.ErrOutOfGas.Error())
 			} else {
 				// otherwise, make sure we get a good success
 				_, err = querier(ctx, []string{types.QueryContractStore}, abci.RequestQuery{Data: []byte(bz)})


### PR DESCRIPTION
## Summary of changes
External contract query, which is causing out-of-gas, also causes core node panic. 
In this PR, I added recover statement to prevent panic from the out-of-gas error.

close #431 

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
