### PR TITLE
[Feature] append blocking conditions for `/txs` query with `--public` flag on LCD

### DIFF
--- a/client/lcd/swagger-ui/swagger.yaml
+++ b/client/lcd/swagger-ui/swagger.yaml
@@ -263,7 +263,7 @@ paths:
         - in: query
           name: message.sender
           type: string
-          description: "transaction tags with sender: 'GET /txs?message.action=send&message.sender=terra1wg2mlrxdmnnkkykgqg4znky86nyrtc45q336yv'"
+          description: "transaction events with sender: 'GET /txs?message.action=send&message.sender=terra1wg2mlrxdmnnkkykgqg4znky86nyrtc45q336yv'"
           x-example: "terra1wg2mlrxdmnnkkykgqg4znky86nyrtc45q336yv"
         - in: query
           name: page
@@ -277,7 +277,15 @@ paths:
           x-example: 1
         - in: query
           name: tx.height
-          description: "Tx height range option. It should be integer or query string(GTE, GT, LTE, LT): `GET /txs?tx.height=\"GTE3,LT10\"` or `GET /txs?tx.height=100`\nIn case using query string, the range can not exceed 100"
+          description: "transaction events with height: 'GET /txs?tx.height=10000'"
+          x-example: 100
+        - in: query
+          name: tx.minheight
+          description: "transaction events with height range option: 'GET /txs?tx.minheight=10000'"
+          x-example: 100
+        - in: query
+          name: tx.maxheight
+          description: "transaction events with height range option: 'GET /txs?tx.maxheight=10000'"
           x-example: 100
       responses:
         200:


### PR DESCRIPTION
## Summary of changes

* Remove custom `tx.height` interpretation
* Update swagger to apply new flags `tx.minheight` & `tx.maxheight`
* Enforce to use` tx.height` or (`tx.maxheight` & `tx.minheight`) events when rest-server is running with `--public` flag

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
