### PR TITLE
[Hotfix] treasury empty epoch data

### DIFF
--- a/x/treasury/abci_test.go
+++ b/x/treasury/abci_test.go
@@ -64,3 +64,43 @@ func TestUpdate(t *testing.T) {
 	newRewardWeight := input.TreasuryKeeper.GetRewardWeight(input.Ctx)
 	require.Equal(t, rewardWeight.Add(input.TreasuryKeeper.RewardPolicy(input.Ctx).ChangeRateMax), newRewardWeight)
 }
+
+func TestEmptyIndicator(t *testing.T) {
+	input := keeper.CreateTestInput(t)
+
+	windowProbation := input.TreasuryKeeper.WindowProbation(input.Ctx)
+
+	// Set total staked luna to prevent divide by zero error when computing TRL
+	bondedModuleAcc := input.SupplyKeeper.GetModuleAccount(input.Ctx, stakingtypes.BondedPoolName)
+	err := bondedModuleAcc.SetCoins(sdk.NewCoins(sdk.NewInt64Coin(core.MicroLunaDenom, 100000000000)))
+	require.NoError(t, err)
+	input.SupplyKeeper.SetModuleAccount(input.Ctx, bondedModuleAcc)
+
+	targetEpoch := windowProbation + 1
+	for epoch := int64(0); epoch < targetEpoch; epoch++ {
+		// skip last epoch end blocker
+		// to make indicators empty
+		if epoch == targetEpoch-1 {
+			continue
+		}
+
+		input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek*epoch - 1)
+		EndBlocker(input.Ctx, input.TreasuryKeeper)
+	}
+
+	// Must result in the same output as normal zero tax & mining rewards
+	// load old tax rate & reward weight
+	taxRate := input.TreasuryKeeper.GetTaxRate(input.Ctx)
+	rewardWeight := input.TreasuryKeeper.GetRewardWeight(input.Ctx)
+
+	input.Ctx = input.Ctx.WithBlockHeight(core.BlocksPerWeek*targetEpoch - 1)
+	EndBlocker(input.Ctx, input.TreasuryKeeper)
+
+	// zero tax proceeds will increase tax rate with change max amount
+	newTaxRate := input.TreasuryKeeper.GetTaxRate(input.Ctx)
+	require.Equal(t, taxRate.Add(input.TreasuryKeeper.TaxPolicy(input.Ctx).ChangeRateMax), newTaxRate)
+
+	// zero mining rewards will increase reward weight with change max amount
+	newRewardWeight := input.TreasuryKeeper.GetRewardWeight(input.Ctx)
+	require.Equal(t, rewardWeight.Add(input.TreasuryKeeper.RewardPolicy(input.Ctx).ChangeRateMax), newRewardWeight)
+}

--- a/x/treasury/internal/keeper/keeper.go
+++ b/x/treasury/internal/keeper/keeper.go
@@ -314,7 +314,7 @@ func (k Keeper) GetTSL(ctx sdk.Context, epoch int64) (res sdk.Int) {
 	bz := store.Get(types.GetTSLKey(epoch))
 
 	if bz == nil {
-		res = sdk.ZeroInt()
+		res = sdk.OneInt()
 	} else {
 		k.cdc.MustUnmarshalBinaryLengthPrefixed(bz, &res)
 	}

--- a/x/treasury/internal/keeper/keeper_test.go
+++ b/x/treasury/internal/keeper/keeper_test.go
@@ -157,7 +157,7 @@ func TestIndicatorGetterSetter(t *testing.T) {
 	for e := int64(0); e < 10; e++ {
 		require.Equal(t, sdk.ZeroDec(), input.TreasuryKeeper.GetTR(input.Ctx, e))
 		require.Equal(t, sdk.ZeroDec(), input.TreasuryKeeper.GetSR(input.Ctx, e))
-		require.Equal(t, sdk.ZeroInt(), input.TreasuryKeeper.GetTSL(input.Ctx, e))
+		require.Equal(t, sdk.OneInt(), input.TreasuryKeeper.GetTSL(input.Ctx, e))
 	}
 }
 


### PR DESCRIPTION
## Summary of changes

fix: #444 

The protection code for `division by zero`, due to empty epoch data, is added.

## Report of required housekeeping

- [x] Github issue OR spec proposal link
- [x] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
