### PR TITLE
[Feature] add tx-gas-hard-limit flag to prevent spamming attack

### DIFF
--- a/cmd/terrad/main.go
+++ b/cmd/terrad/main.go
@@ -28,6 +28,7 @@ import (
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 
 	"github.com/terra-project/core/x/auth"
+	coreante "github.com/terra-project/core/x/auth/ante"
 	"github.com/terra-project/core/x/staking"
 	wasmconfig "github.com/terra-project/core/x/wasm/config"
 )
@@ -73,6 +74,12 @@ func main() {
 	executor := cli.PrepareBaseCmd(rootCmd, "TE", app.DefaultNodeHome)
 	rootCmd.PersistentFlags().UintVar(&invCheckPeriod, flagInvCheckPeriod,
 		0, "Assert registered invariants every N blocks")
+
+	// register tx gas hard cap flag
+	rootCmd.PersistentFlags().Uint64(coreante.FlagTxGasHardLimit, uint64(30000000),
+		"Transaction hard cap to prevent spamming attack")
+	viper.BindPFlag(coreante.FlagTxGasHardLimit, rootCmd.Flags().Lookup(coreante.FlagTxGasHardLimit))
+
 	err := executor.Execute()
 	if err != nil {
 		panic(err)

--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -13,7 +13,8 @@ import (
 func NewAnteHandler(ak keeper.AccountKeeper, supplyKeeper types.SupplyKeeper, treasuryKeeper TreasuryKeeper, sigGasConsumer cosmosante.SignatureVerificationGasConsumer) sdk.AnteHandler {
 	return sdk.ChainAnteDecorators(
 		cosmosante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
-		NewTaxFeeDecorator(treasuryKeeper),    // mempool gas fee validation & record tax proceeds
+		NewSpammingPreventionDecorator(),
+		NewTaxFeeDecorator(treasuryKeeper), // mempool gas fee validation & record tax proceeds
 		cosmosante.NewValidateBasicDecorator(),
 		cosmosante.NewValidateMemoDecorator(ak),
 		cosmosante.NewConsumeGasForTxSizeDecorator(ak),

--- a/x/auth/ante/spamming_prevention.go
+++ b/x/auth/ante/spamming_prevention.go
@@ -1,0 +1,36 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/spf13/viper"
+)
+
+// FlagTxGasHardLimit defines the hard cap to prevent tx spamming attack
+const FlagTxGasHardLimit = "tx-gas-hard-limit"
+
+// SpammingPreventionDecorator will check if the transaction's gas is smaller than
+// configured hard cap
+type SpammingPreventionDecorator struct {
+}
+
+// NewSpammingPreventionDecorator returns new spamming prevention decorator instance
+func NewSpammingPreventionDecorator() SpammingPreventionDecorator {
+	return SpammingPreventionDecorator{}
+}
+
+// AnteHandle handles msg tax fee checking
+func (spd SpammingPreventionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	feeTx, ok := tx.(FeeTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+
+	gas := feeTx.GetGas()
+	gasHardLimit := viper.GetUint64(FlagTxGasHardLimit)
+	if gas > gasHardLimit {
+		return ctx, sdkerrors.Wrapf(sdkerrors.ErrOutOfGas, "Tx cannot spend more than %d gas", gasHardLimit)
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/x/auth/ante/spamming_prevention.go
+++ b/x/auth/ante/spamming_prevention.go
@@ -21,15 +21,17 @@ func NewSpammingPreventionDecorator() SpammingPreventionDecorator {
 
 // AnteHandle handles msg tax fee checking
 func (spd SpammingPreventionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	feeTx, ok := tx.(FeeTx)
-	if !ok {
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
-	}
+	if ctx.IsCheckTx() {
+		feeTx, ok := tx.(FeeTx)
+		if !ok {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+		}
 
-	gas := feeTx.GetGas()
-	gasHardLimit := viper.GetUint64(FlagTxGasHardLimit)
-	if gas > gasHardLimit {
-		return ctx, sdkerrors.Wrapf(sdkerrors.ErrOutOfGas, "Tx cannot spend more than %d gas", gasHardLimit)
+		gas := feeTx.GetGas()
+		gasHardLimit := viper.GetUint64(FlagTxGasHardLimit)
+		if gas > gasHardLimit {
+			return ctx, sdkerrors.Wrapf(sdkerrors.ErrOutOfGas, "Tx cannot spend more than %d gas", gasHardLimit)
+		}
 	}
 
 	return next(ctx, tx, simulate)

--- a/x/auth/ante/tax.go
+++ b/x/auth/ante/tax.go
@@ -21,7 +21,7 @@ type FeeTx interface {
 	FeePayer() sdk.AccAddress
 }
 
-// TaxDecorator will check if the transaction's fee is at least as large
+// TaxFeeDecorator will check if the transaction's fee is at least as large
 // as tax + the local validator's minimum gasFee (defined in validator config)
 // and record tax proceeds to treasury module to track tax proceeds.
 // If fee is too low, decorator returns error and tx is rejected from mempool.


### PR DESCRIPTION
## Summary of changes

To prevent spamming attack,

We added new flag `tx-gas-hard-limit` to terrad cmd.

Default tx-gas-hard-limit is 30,000,000.
and node operators can set in any other value.

> This change is only applied to mempool operation (check tx), so can be applied anytime without consensus failure
```
$ terrad start --tx-gas-hard-limit 10,000,000
```

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
