### PR TITLE
[Bugfix] use custom sigverify ante handler to prevent same tx inclusion

### DIFF
--- a/custom/auth/ante/ante.go
+++ b/custom/auth/ante/ante.go
@@ -65,7 +65,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		cosmosante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
 		cosmosante.NewValidateSigCountDecorator(options.AccountKeeper),
 		cosmosante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
-		cosmosante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		cosmosante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewAnteDecorator(options.IBCChannelKeeper),
 	), nil

--- a/custom/auth/ante/sigverify.go
+++ b/custom/auth/ante/sigverify.go
@@ -1,0 +1,508 @@
+package ante
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256r1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	cosmosante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+var (
+	// simulation signature values used to estimate gas consumption
+	key                = make([]byte, secp256k1.PubKeySize)
+	simSecp256k1Pubkey = &secp256k1.PubKey{Key: key}
+	simSecp256k1Sig    [64]byte
+
+	_ authsigning.SigVerifiableTx = (*legacytx.StdTx)(nil) // assert StdTx implements SigVerifiableTx
+)
+
+func init() {
+	// This decodes a valid hex string into a sepc256k1Pubkey for use in transaction simulation
+	bz, _ := hex.DecodeString("035AD6810A47F073553FF30D2FCC7E0D3B1C0B74B61A1AAA2582344037151E143A")
+	copy(key, bz)
+	simSecp256k1Pubkey.Key = key
+}
+
+// SignatureVerificationGasConsumer is the type of function that is used to both
+// consume gas when verifying signatures and also to accept or reject different types of pubkeys
+// This is where apps can define their own PubKey
+type SignatureVerificationGasConsumer = func(meter sdk.GasMeter, sig signing.SignatureV2, params types.Params) error
+
+// SetPubKeyDecorator sets PubKeys in context for any signer which does not already have pubkey set
+// PubKeys must be set in context for all signers before any other sigverify decorators run
+// CONTRACT: Tx must implement SigVerifiableTx interface
+type SetPubKeyDecorator struct {
+	ak cosmosante.AccountKeeper
+}
+
+func NewSetPubKeyDecorator(ak cosmosante.AccountKeeper) SetPubKeyDecorator {
+	return SetPubKeyDecorator{
+		ak: ak,
+	}
+}
+
+func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
+	}
+
+	pubkeys, err := sigTx.GetPubKeys()
+	if err != nil {
+		return ctx, err
+	}
+	signers := sigTx.GetSigners()
+
+	for i, pk := range pubkeys {
+		// PublicKey was omitted from slice since it has already been set in context
+		if pk == nil {
+			if !simulate {
+				continue
+			}
+			pk = simSecp256k1Pubkey
+		}
+		// Only make check if simulate=false
+		if !simulate && !bytes.Equal(pk.Address(), signers[i]) {
+			return ctx, sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey,
+				"pubKey does not match signer address %s with signer index: %d", signers[i], i)
+		}
+
+		acc, err := GetSignerAcc(ctx, spkd.ak, signers[i])
+		if err != nil {
+			return ctx, err
+		}
+		// account already has pubkey set,no need to reset
+		if acc.GetPubKey() != nil {
+			continue
+		}
+		err = acc.SetPubKey(pk)
+		if err != nil {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, err.Error())
+		}
+		spkd.ak.SetAccount(ctx, acc)
+	}
+
+	// Also emit the following events, so that txs can be indexed by these
+	// indices:
+	// - signature (via `tx.signature='<sig_as_base64>'`),
+	// - concat(address,"/",sequence) (via `tx.acc_seq='cosmos1abc...def/42'`).
+	sigs, err := sigTx.GetSignaturesV2()
+	if err != nil {
+		return ctx, err
+	}
+
+	var events sdk.Events
+	for i, sig := range sigs {
+		events = append(events, sdk.NewEvent(sdk.EventTypeTx,
+			sdk.NewAttribute(sdk.AttributeKeyAccountSequence, fmt.Sprintf("%s/%d", signers[i], sig.Sequence)),
+		))
+
+		sigBzs, err := signatureDataToBz(sig.Data)
+		if err != nil {
+			return ctx, err
+		}
+		for _, sigBz := range sigBzs {
+			events = append(events, sdk.NewEvent(sdk.EventTypeTx,
+				sdk.NewAttribute(sdk.AttributeKeySignature, base64.StdEncoding.EncodeToString(sigBz)),
+			))
+		}
+	}
+
+	ctx.EventManager().EmitEvents(events)
+
+	return next(ctx, tx, simulate)
+}
+
+// Consume parameter-defined amount of gas for each signature according to the passed-in SignatureVerificationGasConsumer function
+// before calling the next AnteHandler
+// CONTRACT: Pubkeys are set in context for all signers before this decorator runs
+// CONTRACT: Tx must implement SigVerifiableTx interface
+type SigGasConsumeDecorator struct {
+	ak             cosmosante.AccountKeeper
+	sigGasConsumer SignatureVerificationGasConsumer
+}
+
+func NewSigGasConsumeDecorator(ak cosmosante.AccountKeeper, sigGasConsumer SignatureVerificationGasConsumer) SigGasConsumeDecorator {
+	return SigGasConsumeDecorator{
+		ak:             ak,
+		sigGasConsumer: sigGasConsumer,
+	}
+}
+
+func (sgcd SigGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
+	}
+
+	params := sgcd.ak.GetParams(ctx)
+	sigs, err := sigTx.GetSignaturesV2()
+	if err != nil {
+		return ctx, err
+	}
+
+	// stdSigs contains the sequence number, account number, and signatures.
+	// When simulating, this would just be a 0-length slice.
+	signerAddrs := sigTx.GetSigners()
+
+	for i, sig := range sigs {
+		signerAcc, err := GetSignerAcc(ctx, sgcd.ak, signerAddrs[i])
+		if err != nil {
+			return ctx, err
+		}
+
+		pubKey := signerAcc.GetPubKey()
+
+		// In simulate mode the transaction comes with no signatures, thus if the
+		// account's pubkey is nil, both signature verification and gasKVStore.Set()
+		// shall consume the largest amount, i.e. it takes more gas to verify
+		// secp256k1 keys than ed25519 ones.
+		if simulate && pubKey == nil {
+			pubKey = simSecp256k1Pubkey
+		}
+
+		// make a SignatureV2 with PubKey filled in from above
+		sig = signing.SignatureV2{
+			PubKey:   pubKey,
+			Data:     sig.Data,
+			Sequence: sig.Sequence,
+		}
+
+		err = sgcd.sigGasConsumer(ctx.GasMeter(), sig, params)
+		if err != nil {
+			return ctx, err
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// Verify all signatures for a tx and return an error if any are invalid. Note,
+// the SigVerificationDecorator will not check signatures on ReCheck.
+//
+// CONTRACT: Pubkeys are set in context for all signers before this decorator runs
+// CONTRACT: Tx must implement SigVerifiableTx interface
+type SigVerificationDecorator struct {
+	ak              cosmosante.AccountKeeper
+	signModeHandler authsigning.SignModeHandler
+}
+
+func NewSigVerificationDecorator(ak cosmosante.AccountKeeper, signModeHandler authsigning.SignModeHandler) SigVerificationDecorator {
+	return SigVerificationDecorator{
+		ak:              ak,
+		signModeHandler: signModeHandler,
+	}
+}
+
+// OnlyLegacyAminoSigners checks SignatureData to see if all
+// signers are using SIGN_MODE_LEGACY_AMINO_JSON. If this is the case
+// then the corresponding SignatureV2 struct will not have account sequence
+// explicitly set, and we should skip the explicit verification of sig.Sequence
+// in the SigVerificationDecorator's AnteHandler function.
+func OnlyLegacyAminoSigners(sigData signing.SignatureData) bool {
+	switch v := sigData.(type) {
+	case *signing.SingleSignatureData:
+		return v.SignMode == signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON
+	case *signing.MultiSignatureData:
+		for _, s := range v.Signatures {
+			if !OnlyLegacyAminoSigners(s) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
+	}
+
+	// stdSigs contains the sequence number, account number, and signatures.
+	// When simulating, this would just be a 0-length slice.
+	sigs, err := sigTx.GetSignaturesV2()
+	if err != nil {
+		return ctx, err
+	}
+
+	signerAddrs := sigTx.GetSigners()
+
+	// check that signer length and signature length are the same
+	if len(sigs) != len(signerAddrs) {
+		return ctx, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "invalid number of signer;  expected: %d, got %d", len(signerAddrs), len(sigs))
+	}
+
+	for i, sig := range sigs {
+		acc, err := GetSignerAcc(ctx, svd.ak, signerAddrs[i])
+		if err != nil {
+			return ctx, err
+		}
+
+		// retrieve pubkey
+		pubKey := acc.GetPubKey()
+		if !simulate && pubKey == nil {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey on account is not set")
+		}
+
+		// Check account sequence number.
+		if sig.Sequence != acc.GetSequence() {
+			return ctx, sdkerrors.Wrapf(
+				sdkerrors.ErrWrongSequence,
+				"account sequence mismatch, expected %d, got %d", acc.GetSequence(), sig.Sequence,
+			)
+		}
+
+		// retrieve signer data
+		genesis := ctx.BlockHeight() == 0
+		chainID := ctx.ChainID()
+		var accNum uint64
+		if !genesis {
+			accNum = acc.GetAccountNumber()
+		}
+		signerData := authsigning.SignerData{
+			ChainID:       chainID,
+			AccountNumber: accNum,
+			Sequence:      acc.GetSequence(),
+		}
+
+		// no need to verify signatures on recheck tx
+		if !simulate && !ctx.IsReCheckTx() {
+			err := authsigning.VerifySignature(pubKey, signerData, sig.Data, svd.signModeHandler, tx)
+			if err != nil {
+				var errMsg string
+				if OnlyLegacyAminoSigners(sig.Data) {
+					// If all signers are using SIGN_MODE_LEGACY_AMINO, we rely on VerifySignature to check account sequence number,
+					// and therefore communicate sequence number as a potential cause of error.
+					errMsg = fmt.Sprintf("signature verification failed; please verify account number (%d), sequence (%d) and chain-id (%s)", accNum, acc.GetSequence(), chainID)
+				} else {
+					errMsg = fmt.Sprintf("signature verification failed; please verify account number (%d) and chain-id (%s)", accNum, chainID)
+				}
+				return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, errMsg)
+
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// IncrementSequenceDecorator handles incrementing sequences of all signers.
+// Use the IncrementSequenceDecorator decorator to prevent replay attacks. Note,
+// there is no need to execute IncrementSequenceDecorator on RecheckTX since
+// CheckTx would already bump the sequence number.
+//
+// NOTE: Since CheckTx and DeliverTx state are managed separately, subsequent and
+// sequential txs orginating from the same account cannot be handled correctly in
+// a reliable way unless sequence numbers are managed and tracked manually by a
+// client. It is recommended to instead use multiple messages in a tx.
+type IncrementSequenceDecorator struct {
+	ak cosmosante.AccountKeeper
+}
+
+func NewIncrementSequenceDecorator(ak cosmosante.AccountKeeper) IncrementSequenceDecorator {
+	return IncrementSequenceDecorator{
+		ak: ak,
+	}
+}
+
+func (isd IncrementSequenceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
+	}
+
+	// increment sequence of all signers
+	for _, addr := range sigTx.GetSigners() {
+		acc := isd.ak.GetAccount(ctx, addr)
+		if err := acc.SetSequence(acc.GetSequence() + 1); err != nil {
+			panic(err)
+		}
+
+		isd.ak.SetAccount(ctx, acc)
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// ValidateSigCountDecorator takes in Params and returns errors if there are too many signatures in the tx for the given params
+// otherwise it calls next AnteHandler
+// Use this decorator to set parameterized limit on number of signatures in tx
+// CONTRACT: Tx must implement SigVerifiableTx interface
+type ValidateSigCountDecorator struct {
+	ak cosmosante.AccountKeeper
+}
+
+func NewValidateSigCountDecorator(ak cosmosante.AccountKeeper) ValidateSigCountDecorator {
+	return ValidateSigCountDecorator{
+		ak: ak,
+	}
+}
+
+func (vscd ValidateSigCountDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a sigTx")
+	}
+
+	params := vscd.ak.GetParams(ctx)
+	pubKeys, err := sigTx.GetPubKeys()
+	if err != nil {
+		return ctx, err
+	}
+
+	sigCount := 0
+	for _, pk := range pubKeys {
+		sigCount += CountSubKeys(pk)
+		if uint64(sigCount) > params.TxSigLimit {
+			return ctx, sdkerrors.Wrapf(sdkerrors.ErrTooManySignatures,
+				"signatures: %d, limit: %d", sigCount, params.TxSigLimit)
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// DefaultSigVerificationGasConsumer is the default implementation of SignatureVerificationGasConsumer. It consumes gas
+// for signature verification based upon the public key type. The cost is fetched from the given params and is matched
+// by the concrete type.
+func DefaultSigVerificationGasConsumer(
+	meter sdk.GasMeter, sig signing.SignatureV2, params types.Params,
+) error {
+	pubkey := sig.PubKey
+	switch pubkey := pubkey.(type) {
+	case *ed25519.PubKey:
+		meter.ConsumeGas(params.SigVerifyCostED25519, "ante verify: ed25519")
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "ED25519 public keys are unsupported")
+
+	case *secp256k1.PubKey:
+		meter.ConsumeGas(params.SigVerifyCostSecp256k1, "ante verify: secp256k1")
+		return nil
+
+	case *secp256r1.PubKey:
+		meter.ConsumeGas(params.SigVerifyCostSecp256r1(), "ante verify: secp256r1")
+		return nil
+
+	case multisig.PubKey:
+		multisignature, ok := sig.Data.(*signing.MultiSignatureData)
+		if !ok {
+			return fmt.Errorf("expected %T, got, %T", &signing.MultiSignatureData{}, sig.Data)
+		}
+		err := ConsumeMultisignatureVerificationGas(meter, multisignature, pubkey, params, sig.Sequence)
+		if err != nil {
+			return err
+		}
+		return nil
+
+	default:
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "unrecognized public key type: %T", pubkey)
+	}
+}
+
+// ConsumeMultisignatureVerificationGas consumes gas from a GasMeter for verifying a multisig pubkey signature
+func ConsumeMultisignatureVerificationGas(
+	meter sdk.GasMeter, sig *signing.MultiSignatureData, pubkey multisig.PubKey,
+	params types.Params, accSeq uint64,
+) error {
+
+	size := sig.BitArray.Count()
+	sigIndex := 0
+
+	for i := 0; i < size; i++ {
+		if !sig.BitArray.GetIndex(i) {
+			continue
+		}
+		sigV2 := signing.SignatureV2{
+			PubKey:   pubkey.GetPubKeys()[i],
+			Data:     sig.Signatures[sigIndex],
+			Sequence: accSeq,
+		}
+		err := DefaultSigVerificationGasConsumer(meter, sigV2, params)
+		if err != nil {
+			return err
+		}
+		sigIndex++
+	}
+
+	return nil
+}
+
+// GetSignerAcc returns an account for a given address that is expected to sign
+// a transaction.
+func GetSignerAcc(ctx sdk.Context, ak cosmosante.AccountKeeper, addr sdk.AccAddress) (types.AccountI, error) {
+	if acc := ak.GetAccount(ctx, addr); acc != nil {
+		return acc, nil
+	}
+
+	return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
+}
+
+// CountSubKeys counts the total number of keys for a multi-sig public key.
+func CountSubKeys(pub cryptotypes.PubKey) int {
+	v, ok := pub.(*kmultisig.LegacyAminoPubKey)
+	if !ok {
+		return 1
+	}
+
+	numKeys := 0
+	for _, subkey := range v.GetPubKeys() {
+		numKeys += CountSubKeys(subkey)
+	}
+
+	return numKeys
+}
+
+// signatureDataToBz converts a SignatureData into raw bytes signature.
+// For SingleSignatureData, it returns the signature raw bytes.
+// For MultiSignatureData, it returns an array of all individual signatures,
+// as well as the aggregated signature.
+func signatureDataToBz(data signing.SignatureData) ([][]byte, error) {
+	if data == nil {
+		return nil, fmt.Errorf("got empty SignatureData")
+	}
+
+	switch data := data.(type) {
+	case *signing.SingleSignatureData:
+		return [][]byte{data.Signature}, nil
+	case *signing.MultiSignatureData:
+		sigs := [][]byte{}
+		var err error
+
+		for _, d := range data.Signatures {
+			nestedSigs, err := signatureDataToBz(d)
+			if err != nil {
+				return nil, err
+			}
+			sigs = append(sigs, nestedSigs...)
+		}
+
+		multisig := cryptotypes.MultiSignature{
+			Signatures: sigs,
+		}
+		aggregatedSig, err := multisig.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		sigs = append(sigs, aggregatedSig)
+
+		return sigs, nil
+	default:
+		return nil, sdkerrors.ErrInvalidType.Wrapf("unexpected signature data type %T", data)
+	}
+}

--- a/custom/auth/ante/sigverify_benchmark_test.go
+++ b/custom/auth/ante/sigverify_benchmark_test.go
@@ -1,0 +1,44 @@
+package ante_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	tmcrypto "github.com/tendermint/tendermint/crypto"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256r1"
+)
+
+// This benchmark is used to asses the ante.Secp256k1ToR1GasFactor value
+func BenchmarkSig(b *testing.B) {
+	require := require.New(b)
+	msg := tmcrypto.CRandBytes(1000)
+
+	skK := secp256k1.GenPrivKey()
+	pkK := skK.PubKey()
+	skR, _ := secp256r1.GenPrivKey()
+	pkR := skR.PubKey()
+
+	sigK, err := skK.Sign(msg)
+	require.NoError(err)
+	sigR, err := skR.Sign(msg)
+	require.NoError(err)
+	b.ResetTimer()
+
+	b.Run("secp256k1", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ok := pkK.VerifySignature(msg, sigK)
+			require.True(ok)
+		}
+	})
+
+	b.Run("secp256r1", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ok := pkR.VerifySignature(msg, sigR)
+			require.True(ok)
+		}
+	})
+}

--- a/custom/auth/ante/sigverify_test.go
+++ b/custom/auth/ante/sigverify_test.go
@@ -1,0 +1,407 @@
+package ante_test
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256r1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+func (suite *AnteTestSuite) TestSetPubKey() {
+	suite.SetupTest(true) // setup
+	require := suite.Require()
+	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+
+	// keys and addresses
+	priv1, pub1, addr1 := testdata.KeyTestPubAddr()
+	priv2, pub2, addr2 := testdata.KeyTestPubAddr()
+	priv3, pub3, addr3 := testdata.KeyTestPubAddrSecp256R1(require)
+
+	addrs := []sdk.AccAddress{addr1, addr2, addr3}
+	pubs := []cryptotypes.PubKey{pub1, pub2, pub3}
+
+	msgs := make([]sdk.Msg, len(addrs))
+	// set accounts and create msg for each address
+	for i, addr := range addrs {
+		acc := suite.app.AccountKeeper.NewAccountWithAddress(suite.ctx, addr)
+		require.NoError(acc.SetAccountNumber(uint64(i)))
+		suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
+		msgs[i] = testdata.NewTestMsg(addr)
+	}
+	require.NoError(suite.txBuilder.SetMsgs(msgs...))
+	suite.txBuilder.SetFeeAmount(testdata.NewTestFeeAmount())
+	suite.txBuilder.SetGasLimit(testdata.NewTestGasLimit())
+
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1, priv2, priv3}, []uint64{0, 1, 2}, []uint64{0, 0, 0}
+	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	require.NoError(err)
+
+	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper)
+	antehandler := sdk.ChainAnteDecorators(spkd)
+
+	ctx, err := antehandler(suite.ctx, tx, false)
+	require.NoError(err)
+
+	// Require that all accounts have pubkey set after Decorator runs
+	for i, addr := range addrs {
+		pk, err := suite.app.AccountKeeper.GetPubKey(ctx, addr)
+		require.NoError(err, "Error on retrieving pubkey from account")
+		require.True(pubs[i].Equals(pk),
+			"Wrong Pubkey retrieved from AccountKeeper, idx=%d\nexpected=%s\n     got=%s", i, pubs[i], pk)
+	}
+}
+
+func (suite *AnteTestSuite) TestConsumeSignatureVerificationGas() {
+	params := types.DefaultParams()
+	msg := []byte{1, 2, 3, 4}
+	cdc := simapp.MakeTestEncodingConfig().Amino
+
+	p := types.DefaultParams()
+	skR1, _ := secp256r1.GenPrivKey()
+	pkSet1, sigSet1 := generatePubKeysAndSignatures(5, msg, false)
+	multisigKey1 := kmultisig.NewLegacyAminoPubKey(2, pkSet1)
+	multisignature1 := multisig.NewMultisig(len(pkSet1))
+	expectedCost1 := expectedGasCostByKeys(pkSet1)
+	for i := 0; i < len(pkSet1); i++ {
+		stdSig := legacytx.StdSignature{PubKey: pkSet1[i], Signature: sigSet1[i]}
+		sigV2, err := legacytx.StdSignatureToSignatureV2(cdc, stdSig)
+		suite.Require().NoError(err)
+		err = multisig.AddSignatureV2(multisignature1, sigV2, pkSet1)
+		suite.Require().NoError(err)
+	}
+
+	type args struct {
+		meter  sdk.GasMeter
+		sig    signing.SignatureData
+		pubkey cryptotypes.PubKey
+		params types.Params
+	}
+	tests := []struct {
+		name        string
+		args        args
+		gasConsumed uint64
+		shouldErr   bool
+	}{
+		{"PubKeyEd25519", args{sdk.NewInfiniteGasMeter(), nil, ed25519.GenPrivKey().PubKey(), params}, p.SigVerifyCostED25519, true},
+		{"PubKeySecp256k1", args{sdk.NewInfiniteGasMeter(), nil, secp256k1.GenPrivKey().PubKey(), params}, p.SigVerifyCostSecp256k1, false},
+		{"PubKeySecp256r1", args{sdk.NewInfiniteGasMeter(), nil, skR1.PubKey(), params}, p.SigVerifyCostSecp256r1(), false},
+		{"Multisig", args{sdk.NewInfiniteGasMeter(), multisignature1, multisigKey1, params}, expectedCost1, false},
+		{"unknown key", args{sdk.NewInfiniteGasMeter(), nil, nil, params}, 0, true},
+	}
+	for _, tt := range tests {
+		sigV2 := signing.SignatureV2{
+			PubKey:   tt.args.pubkey,
+			Data:     tt.args.sig,
+			Sequence: 0, // Arbitrary account sequence
+		}
+		err := ante.DefaultSigVerificationGasConsumer(tt.args.meter, sigV2, tt.args.params)
+
+		if tt.shouldErr {
+			suite.Require().NotNil(err)
+		} else {
+			suite.Require().Nil(err)
+			suite.Require().Equal(tt.gasConsumed, tt.args.meter.GasConsumed(), fmt.Sprintf("%d != %d", tt.gasConsumed, tt.args.meter.GasConsumed()))
+		}
+	}
+}
+
+func (suite *AnteTestSuite) TestSigVerification() {
+	suite.SetupTest(true) // setup
+	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+
+	// make block height non-zero to ensure account numbers part of signBytes
+	suite.ctx = suite.ctx.WithBlockHeight(1)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	priv2, _, addr2 := testdata.KeyTestPubAddr()
+	priv3, _, addr3 := testdata.KeyTestPubAddr()
+
+	addrs := []sdk.AccAddress{addr1, addr2, addr3}
+
+	msgs := make([]sdk.Msg, len(addrs))
+	// set accounts and create msg for each address
+	for i, addr := range addrs {
+		acc := suite.app.AccountKeeper.NewAccountWithAddress(suite.ctx, addr)
+		suite.Require().NoError(acc.SetAccountNumber(uint64(i)))
+		suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
+		msgs[i] = testdata.NewTestMsg(addr)
+	}
+
+	feeAmount := testdata.NewTestFeeAmount()
+	gasLimit := testdata.NewTestGasLimit()
+
+	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper)
+	svd := ante.NewSigVerificationDecorator(suite.app.AccountKeeper, suite.clientCtx.TxConfig.SignModeHandler())
+	antehandler := sdk.ChainAnteDecorators(spkd, svd)
+
+	type testCase struct {
+		name        string
+		privs       []cryptotypes.PrivKey
+		accNums     []uint64
+		accSeqs     []uint64
+		invalidSigs bool
+		recheck     bool
+		shouldErr   bool
+	}
+	validSigs := false
+	testCases := []testCase{
+		{"no signers", []cryptotypes.PrivKey{}, []uint64{}, []uint64{}, validSigs, false, true},
+		{"not enough signers", []cryptotypes.PrivKey{priv1, priv2}, []uint64{0, 1}, []uint64{0, 0}, validSigs, false, true},
+		{"wrong order signers", []cryptotypes.PrivKey{priv3, priv2, priv1}, []uint64{2, 1, 0}, []uint64{0, 0, 0}, validSigs, false, true},
+		{"wrong accnums", []cryptotypes.PrivKey{priv1, priv2, priv3}, []uint64{7, 8, 9}, []uint64{0, 0, 0}, validSigs, false, true},
+		{"wrong sequences", []cryptotypes.PrivKey{priv1, priv2, priv3}, []uint64{0, 1, 2}, []uint64{3, 4, 5}, validSigs, false, true},
+		{"valid tx", []cryptotypes.PrivKey{priv1, priv2, priv3}, []uint64{0, 1, 2}, []uint64{0, 0, 0}, validSigs, false, false},
+		{"no err on recheck", []cryptotypes.PrivKey{priv1, priv2, priv3}, []uint64{0, 0, 0}, []uint64{0, 0, 0}, !validSigs, true, false},
+	}
+	for i, tc := range testCases {
+		suite.ctx = suite.ctx.WithIsReCheckTx(tc.recheck)
+		suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder() // Create new txBuilder for each test
+
+		suite.Require().NoError(suite.txBuilder.SetMsgs(msgs...))
+		suite.txBuilder.SetFeeAmount(feeAmount)
+		suite.txBuilder.SetGasLimit(gasLimit)
+
+		tx, err := suite.CreateTestTx(tc.privs, tc.accNums, tc.accSeqs, suite.ctx.ChainID())
+		suite.Require().NoError(err)
+		if tc.invalidSigs {
+			txSigs, _ := tx.GetSignaturesV2()
+			badSig, _ := tc.privs[0].Sign([]byte("unrelated message"))
+			txSigs[0] = signing.SignatureV2{
+				PubKey: tc.privs[0].PubKey(),
+				Data: &signing.SingleSignatureData{
+					SignMode:  suite.clientCtx.TxConfig.SignModeHandler().DefaultMode(),
+					Signature: badSig,
+				},
+				Sequence: tc.accSeqs[0],
+			}
+			suite.txBuilder.SetSignatures(txSigs...)
+			tx = suite.txBuilder.GetTx()
+		}
+
+		_, err = antehandler(suite.ctx, tx, false)
+		if tc.shouldErr {
+			suite.Require().NotNil(err, "TestCase %d: %s did not error as expected", i, tc.name)
+		} else {
+			suite.Require().Nil(err, "TestCase %d: %s errored unexpectedly. Err: %v", i, tc.name, err)
+		}
+	}
+}
+
+// This test is exactly like the one above, but we set the codec explicitly to
+// Amino.
+// Once https://github.com/cosmos/cosmos-sdk/issues/6190 is in, we can remove
+// this, since it'll be handled by the test matrix.
+// In the meantime, we want to make double-sure amino compatibility works.
+// ref: https://github.com/cosmos/cosmos-sdk/issues/7229
+func (suite *AnteTestSuite) TestSigVerification_ExplicitAmino() {
+	tempDir := suite.T().TempDir()
+	suite.app, suite.ctx = createTestApp(true, tempDir)
+	suite.ctx = suite.ctx.WithBlockHeight(1)
+
+	// Set up TxConfig.
+	aminoCdc := codec.NewLegacyAmino()
+	// We're using TestMsg amino encoding in some tests, so register it here.
+	txConfig := legacytx.StdTxConfig{Cdc: aminoCdc}
+
+	suite.clientCtx = client.Context{}.
+		WithTxConfig(txConfig)
+
+	anteHandler, err := ante.NewAnteHandler(
+		ante.HandlerOptions{
+			AccountKeeper:   suite.app.AccountKeeper,
+			BankKeeper:      suite.app.BankKeeper,
+			FeegrantKeeper:  suite.app.FeeGrantKeeper,
+			SignModeHandler: txConfig.SignModeHandler(),
+			SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
+		},
+	)
+
+	suite.Require().NoError(err)
+	suite.anteHandler = anteHandler
+
+	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+
+	// make block height non-zero to ensure account numbers part of signBytes
+	suite.ctx = suite.ctx.WithBlockHeight(1)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	priv2, _, addr2 := testdata.KeyTestPubAddr()
+	priv3, _, addr3 := testdata.KeyTestPubAddr()
+
+	addrs := []sdk.AccAddress{addr1, addr2, addr3}
+
+	msgs := make([]sdk.Msg, len(addrs))
+	// set accounts and create msg for each address
+	for i, addr := range addrs {
+		acc := suite.app.AccountKeeper.NewAccountWithAddress(suite.ctx, addr)
+		suite.Require().NoError(acc.SetAccountNumber(uint64(i)))
+		suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
+		msgs[i] = testdata.NewTestMsg(addr)
+	}
+
+	feeAmount := testdata.NewTestFeeAmount()
+	gasLimit := testdata.NewTestGasLimit()
+
+	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper)
+	svd := ante.NewSigVerificationDecorator(suite.app.AccountKeeper, suite.clientCtx.TxConfig.SignModeHandler())
+	antehandler := sdk.ChainAnteDecorators(spkd, svd)
+
+	type testCase struct {
+		name      string
+		privs     []cryptotypes.PrivKey
+		accNums   []uint64
+		accSeqs   []uint64
+		recheck   bool
+		shouldErr bool
+	}
+	testCases := []testCase{
+		{"no signers", []cryptotypes.PrivKey{}, []uint64{}, []uint64{}, false, true},
+		{"not enough signers", []cryptotypes.PrivKey{priv1, priv2}, []uint64{0, 1}, []uint64{0, 0}, false, true},
+		{"wrong order signers", []cryptotypes.PrivKey{priv3, priv2, priv1}, []uint64{2, 1, 0}, []uint64{0, 0, 0}, false, true},
+		{"wrong accnums", []cryptotypes.PrivKey{priv1, priv2, priv3}, []uint64{7, 8, 9}, []uint64{0, 0, 0}, false, true},
+		{"wrong sequences", []cryptotypes.PrivKey{priv1, priv2, priv3}, []uint64{0, 1, 2}, []uint64{3, 4, 5}, false, true},
+		{"valid tx", []cryptotypes.PrivKey{priv1, priv2, priv3}, []uint64{0, 1, 2}, []uint64{0, 0, 0}, false, false},
+		{"no err on recheck", []cryptotypes.PrivKey{priv1, priv2, priv3}, []uint64{0, 1, 2}, []uint64{0, 0, 0}, true, false},
+	}
+	for i, tc := range testCases {
+		suite.ctx = suite.ctx.WithIsReCheckTx(tc.recheck)
+		suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder() // Create new txBuilder for each test
+
+		suite.Require().NoError(suite.txBuilder.SetMsgs(msgs...))
+		suite.txBuilder.SetFeeAmount(feeAmount)
+		suite.txBuilder.SetGasLimit(gasLimit)
+
+		tx, err := suite.CreateTestTx(tc.privs, tc.accNums, tc.accSeqs, suite.ctx.ChainID())
+		suite.Require().NoError(err)
+
+		_, err = antehandler(suite.ctx, tx, false)
+		if tc.shouldErr {
+			suite.Require().NotNil(err, "TestCase %d: %s did not error as expected", i, tc.name)
+		} else {
+			suite.Require().Nil(err, "TestCase %d: %s errored unexpectedly. Err: %v", i, tc.name, err)
+		}
+	}
+}
+
+func (suite *AnteTestSuite) TestSigIntegration() {
+	// generate private keys
+	privs := []cryptotypes.PrivKey{
+		secp256k1.GenPrivKey(),
+		secp256k1.GenPrivKey(),
+		secp256k1.GenPrivKey(),
+	}
+
+	params := types.DefaultParams()
+	initialSigCost := params.SigVerifyCostSecp256k1
+	initialCost, err := suite.runSigDecorators(params, false, privs...)
+	suite.Require().Nil(err)
+
+	params.SigVerifyCostSecp256k1 *= 2
+	doubleCost, err := suite.runSigDecorators(params, false, privs...)
+	suite.Require().Nil(err)
+
+	suite.Require().Equal(initialSigCost*uint64(len(privs)), doubleCost-initialCost)
+}
+
+func (suite *AnteTestSuite) runSigDecorators(params types.Params, _ bool, privs ...cryptotypes.PrivKey) (sdk.Gas, error) {
+	suite.SetupTest(true) // setup
+	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+
+	// Make block-height non-zero to include accNum in SignBytes
+	suite.ctx = suite.ctx.WithBlockHeight(1)
+	suite.app.AccountKeeper.SetParams(suite.ctx, params)
+
+	msgs := make([]sdk.Msg, len(privs))
+	accNums := make([]uint64, len(privs))
+	accSeqs := make([]uint64, len(privs))
+	// set accounts and create msg for each address
+	for i, priv := range privs {
+		addr := sdk.AccAddress(priv.PubKey().Address())
+		acc := suite.app.AccountKeeper.NewAccountWithAddress(suite.ctx, addr)
+		suite.Require().NoError(acc.SetAccountNumber(uint64(i)))
+		suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
+		msgs[i] = testdata.NewTestMsg(addr)
+		accNums[i] = uint64(i)
+		accSeqs[i] = uint64(0)
+	}
+	suite.Require().NoError(suite.txBuilder.SetMsgs(msgs...))
+
+	feeAmount := testdata.NewTestFeeAmount()
+	gasLimit := testdata.NewTestGasLimit()
+	suite.txBuilder.SetFeeAmount(feeAmount)
+	suite.txBuilder.SetGasLimit(gasLimit)
+
+	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper)
+	svgc := ante.NewSigGasConsumeDecorator(suite.app.AccountKeeper, ante.DefaultSigVerificationGasConsumer)
+	svd := ante.NewSigVerificationDecorator(suite.app.AccountKeeper, suite.clientCtx.TxConfig.SignModeHandler())
+	antehandler := sdk.ChainAnteDecorators(spkd, svgc, svd)
+
+	// Determine gas consumption of antehandler with default params
+	before := suite.ctx.GasMeter().GasConsumed()
+	ctx, err := antehandler(suite.ctx, tx, false)
+	after := ctx.GasMeter().GasConsumed()
+
+	return after - before, err
+}
+
+func (suite *AnteTestSuite) TestIncrementSequenceDecorator() {
+	suite.SetupTest(true) // setup
+	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+
+	priv, _, addr := testdata.KeyTestPubAddr()
+	acc := suite.app.AccountKeeper.NewAccountWithAddress(suite.ctx, addr)
+	suite.Require().NoError(acc.SetAccountNumber(uint64(50)))
+	suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
+
+	msgs := []sdk.Msg{testdata.NewTestMsg(addr)}
+	suite.Require().NoError(suite.txBuilder.SetMsgs(msgs...))
+	privs := []cryptotypes.PrivKey{priv}
+	accNums := []uint64{suite.app.AccountKeeper.GetAccount(suite.ctx, addr).GetAccountNumber()}
+	accSeqs := []uint64{suite.app.AccountKeeper.GetAccount(suite.ctx, addr).GetSequence()}
+	feeAmount := testdata.NewTestFeeAmount()
+	gasLimit := testdata.NewTestGasLimit()
+	suite.txBuilder.SetFeeAmount(feeAmount)
+	suite.txBuilder.SetGasLimit(gasLimit)
+
+	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	isd := ante.NewIncrementSequenceDecorator(suite.app.AccountKeeper)
+	antehandler := sdk.ChainAnteDecorators(isd)
+
+	testCases := []struct {
+		ctx         sdk.Context
+		simulate    bool
+		expectedSeq uint64
+	}{
+		{suite.ctx.WithIsReCheckTx(true), false, 1},
+		{suite.ctx.WithIsCheckTx(true).WithIsReCheckTx(false), false, 2},
+		{suite.ctx.WithIsReCheckTx(true), false, 3},
+		{suite.ctx.WithIsReCheckTx(true), false, 4},
+		{suite.ctx.WithIsReCheckTx(true), true, 5},
+	}
+
+	for i, tc := range testCases {
+		_, err := antehandler(tc.ctx, tx, tc.simulate)
+		suite.Require().NoError(err, "unexpected error; tc #%d, %v", i, tc)
+		suite.Require().Equal(tc.expectedSeq, suite.app.AccountKeeper.GetAccount(suite.ctx, addr).GetSequence())
+	}
+}


### PR DESCRIPTION
## Summary of changes

pick https://github.com/osmosis-labs/cosmos-sdk/pull/58

to prevent duplicate txs. 

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
